### PR TITLE
Add support for the SYCL backend for Alpaka

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,11 +139,13 @@ ONEAPI_ENV    := $(ONEAPI_BASE)/setvars.sh
 SYCL_BASE     := $(ONEAPI_BASE)/compiler/$(SYCL_VERSION)/linux
 TBB_BASE := $(ONEAPI_BASE)/tbb/latest
 TBB_LIBDIR := $(TBB_BASE)/lib/intel64/gcc4.8
-USER_SYCLFLAGS := -fp-model=precise -fimf-arch-consistency=true -no-fma -Wsycl-strict -fsycl-targets=spir64_x86_64,spir64_gen -Xsycl-target-backend=spir64_gen "-device xe_hp_sdv"
+USER_SYCLFLAGS := -fp-model=precise -fimf-arch-consistency=true -no-fma -fsycl-targets=spir64_x86_64,spir64_gen -Xsycl-target-backend=spir64_gen "-device xe_hp_sdv"
 export SYCL_CXX      := $(SYCL_BASE)/bin/dpcpp
 export SYCL_CXXFLAGS := -fsycl -Wsycl-strict $(filter-out $(SYCL_UNSUPPORTED_CXXFLAGS),$(CXXFLAGS)) $(USER_SYCLFLAGS)
 endif
 endif
+
+export SYCL_BASE
 
 # to use a different toolchain
 #   - unset ONEAPI_ENV
@@ -619,8 +621,7 @@ $(HWLOC_BASE):
 external_alpaka: $(ALPAKA_BASE)
 
 $(ALPAKA_BASE):
-	git clone git@github.com:alpaka-group/alpaka.git -b develop $@
-	cd $@ && git checkout b518e8c943a816eba06c3e12c0a7e1b58c8faedc
+	git clone https://github.com/Parsifal-2045/alpaka.git -b develop $@
 
 # Kokkos
 external_kokkos: $(KOKKOS_LIB)

--- a/Makefile
+++ b/Makefile
@@ -623,7 +623,8 @@ $(HWLOC_BASE):
 external_alpaka: $(ALPAKA_BASE)
 
 $(ALPAKA_BASE):
-	git clone https://github.com/Parsifal-2045/alpaka.git -b SYCL_USM $@
+	git clone https://github.com/alpaka-group/alpaka.git -b develop $@
+	cd $@ && git checkout 23edf577e58015a5a20af2db5f8c5892e043ef80
 
 # Kokkos
 external_kokkos: $(KOKKOS_LIB)

--- a/src/alpaka/AlpakaCore/AllocatorPolicy.h
+++ b/src/alpaka/AlpakaCore/AllocatorPolicy.h
@@ -48,7 +48,7 @@ namespace cms::alpakatools {
 
 #if defined ALPAKA_SYCL_ONEAPI_CPU
   template <>
-  constexpr inline AllocatorPolicy allocator_policy<alpaka::DevCpuSyclIntel> =
+  constexpr inline AllocatorPolicy allocator_policy<alpaka::DevCpuSycl> =
 #if !defined ALPAKA_DISABLE_CACHING_ALLOCATOR
       AllocatorPolicy::Caching;
 #else

--- a/src/alpaka/AlpakaCore/AllocatorPolicy.h
+++ b/src/alpaka/AlpakaCore/AllocatorPolicy.h
@@ -46,6 +46,26 @@ namespace cms::alpakatools {
 #endif
 #endif  // ALPAKA_ACC_GPU_HIP_ENABLED
 
+#if defined ALPAKA_SYCL_ONEAPI_CPU
+  template <>
+  constexpr inline AllocatorPolicy allocator_policy<alpaka::DevCpuSyclIntel> =
+#if !defined ALPAKA_DISABLE_CACHING_ALLOCATOR
+      AllocatorPolicy::Caching;
+#else
+      AllocatorPolicy::Synchronous;
+#endif
+#endif  // ALPAKA_SYCL_ONEAPI_CPU
+
+#if defined ALPAKA_SYCL_ONEAPI_GPU
+  template <>
+  constexpr inline AllocatorPolicy allocator_policy<alpaka::DevGpuSyclIntel> =
+#if !defined ALPAKA_DISABLE_CACHING_ALLOCATOR
+      AllocatorPolicy::Caching;
+#else
+      AllocatorPolicy::Synchronous;
+#endif
+#endif  // ALPAKA_SYCL_ONEAPI_GPU
+
 }  // namespace cms::alpakatools
 
 #endif  // AlpakaCore_AllocatorPolicy_h

--- a/src/alpaka/AlpakaCore/CachedBufAlloc.h
+++ b/src/alpaka/AlpakaCore/CachedBufAlloc.h
@@ -138,14 +138,14 @@ namespace cms::alpakatools {
 
     //! The caching memory allocator implementation for the pinned host memory
     template <typename TElem, typename TDim, typename TIdx>
-    struct CachedBufAlloc<TElem, TDim, TIdx, alpaka::DevCpu, alpaka::QueueCpuSyclIntelNonBlocking, void> {
+    struct CachedBufAlloc<TElem, TDim, TIdx, alpaka::DevCpu, alpaka::QueueCpuSyclNonBlocking, void> {
       template <typename TExtent>
       ALPAKA_FN_HOST static auto allocCachedBuf(alpaka::DevCpu const& dev,
-                                                alpaka::QueueCpuSyclIntelNonBlocking queue,
+                                                alpaka::QueueCpuSyclNonBlocking queue,
                                                 TExtent const& extent) -> alpaka::BufCpu<TElem, TDim, TIdx> {
         ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
-        auto& allocator = getHostCachingAllocator<alpaka::QueueCpuSyclIntelNonBlocking>();
+        auto& allocator = getHostCachingAllocator<alpaka::QueueCpuSyclNonBlocking>();
 
         // FIXME the BufCpu does not support a pitch ?
         size_t size = alpaka::getExtentProduct(extent);
@@ -161,13 +161,13 @@ namespace cms::alpakatools {
 
     //! The caching memory allocator implementation for the SYCL CPU device
     template <typename TElem, typename TDim, typename TIdx, typename TQueue>
-    struct CachedBufAlloc<TElem, TDim, TIdx, alpaka::DevCpuSyclIntel, TQueue, void> {
+    struct CachedBufAlloc<TElem, TDim, TIdx, alpaka::DevCpuSycl, TQueue, void> {
       template <typename TExtent>
-      ALPAKA_FN_HOST static auto allocCachedBuf(alpaka::DevCpuSyclIntel const& dev, TQueue queue, TExtent const& extent)
-          -> alpaka::BufCpuSyclIntel<TElem, TDim, TIdx> {
+      ALPAKA_FN_HOST static auto allocCachedBuf(alpaka::DevCpuSycl const& dev, TQueue queue, TExtent const& extent)
+          -> alpaka::BufCpuSycl<TElem, TDim, TIdx> {
         ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
-        auto& allocator = getDeviceCachingAllocator<alpaka::DevCpuSyclIntel, TQueue>(dev);
+        auto& allocator = getDeviceCachingAllocator<alpaka::DevCpuSycl, TQueue>(dev);
 
         // TODO implement pitch for TDim > 1
         size_t size = alpaka::getExtentProduct(extent);
@@ -177,7 +177,7 @@ namespace cms::alpakatools {
         // use a custom deleter to return the buffer to the CachingAllocator
         auto deleter = [alloc = &allocator](TElem* ptr) { alloc->free(ptr); };
 
-        return alpaka::BufCpuSyclIntel<TElem, TDim, TIdx>(
+        return alpaka::BufCpuSycl<TElem, TDim, TIdx>(
             dev, reinterpret_cast<TElem*>(memPtr), std::move(deleter), extent);
       }
     };

--- a/src/alpaka/AlpakaCore/CachedBufAlloc.h
+++ b/src/alpaka/AlpakaCore/CachedBufAlloc.h
@@ -134,6 +134,105 @@ namespace cms::alpakatools {
 
 #endif  // ALPAKA_ACC_GPU_HIP_ENABLED
 
+#ifdef ALPAKA_SYCL_ONEAPI_CPU
+
+    //! The caching memory allocator implementation for the pinned host memory
+    template <typename TElem, typename TDim, typename TIdx>
+    struct CachedBufAlloc<TElem, TDim, TIdx, alpaka::DevCpu, alpaka::QueueCpuSyclIntelNonBlocking, void> {
+      template <typename TExtent>
+      ALPAKA_FN_HOST static auto allocCachedBuf(alpaka::DevCpu const& dev,
+                                                alpaka::QueueCpuSyclIntelNonBlocking queue,
+                                                TExtent const& extent) -> alpaka::BufCpu<TElem, TDim, TIdx> {
+        ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
+
+        auto& allocator = getHostCachingAllocator<alpaka::QueueCpuSyclIntelNonBlocking>();
+
+        // FIXME the BufCpu does not support a pitch ?
+        size_t size = alpaka::getExtentProduct(extent);
+        size_t sizeBytes = size * sizeof(TElem);
+        void* memPtr = allocator.allocate(sizeBytes, queue);
+
+        // use a custom deleter to return the buffer to the CachingAllocator
+        auto deleter = [alloc = &allocator](TElem* ptr) { alloc->free(ptr); };
+
+        return alpaka::BufCpu<TElem, TDim, TIdx>(dev, reinterpret_cast<TElem*>(memPtr), std::move(deleter), extent);
+      }
+    };
+
+    //! The caching memory allocator implementation for the SYCL CPU device
+    template <typename TElem, typename TDim, typename TIdx, typename TQueue>
+    struct CachedBufAlloc<TElem, TDim, TIdx, alpaka::DevCpuSyclIntel, TQueue, void> {
+      template <typename TExtent>
+      ALPAKA_FN_HOST static auto allocCachedBuf(alpaka::DevCpuSyclIntel const& dev, TQueue queue, TExtent const& extent)
+          -> alpaka::BufCpuSyclIntel<TElem, TDim, TIdx> {
+        ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
+
+        auto& allocator = getDeviceCachingAllocator<alpaka::DevCpuSyclIntel, TQueue>(dev);
+
+        // TODO implement pitch for TDim > 1
+        size_t size = alpaka::getExtentProduct(extent);
+        size_t sizeBytes = size * sizeof(TElem);
+        void* memPtr = allocator.allocate(sizeBytes, queue);
+
+        // use a custom deleter to return the buffer to the CachingAllocator
+        auto deleter = [alloc = &allocator](TElem* ptr) { alloc->free(ptr); };
+
+        return alpaka::BufCpuSyclIntel<TElem, TDim, TIdx>(
+            dev, reinterpret_cast<TElem*>(memPtr), std::move(deleter), extent);
+      }
+    };
+
+#endif  // ALPAKA_SYCL_ONEAPI_CPU
+
+#ifdef ALPAKA_SYCL_ONEAPI_GPU
+
+    //! The caching memory allocator implementation for the pinned host memory
+    template <typename TElem, typename TDim, typename TIdx>
+    struct CachedBufAlloc<TElem, TDim, TIdx, alpaka::DevCpu, alpaka::QueueGpuSyclIntelNonBlocking, void> {
+      template <typename TExtent>
+      ALPAKA_FN_HOST static auto allocCachedBuf(alpaka::DevCpu const& dev,
+                                                alpaka::QueueGpuSyclIntelNonBlocking queue,
+                                                TExtent const& extent) -> alpaka::BufCpu<TElem, TDim, TIdx> {
+        ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
+
+        auto& allocator = getHostCachingAllocator<alpaka::QueueGpuSyclIntelNonBlocking>();
+
+        size_t size = alpaka::getExtentProduct(extent);
+        size_t sizeBytes = size * sizeof(TElem);
+        void* memPtr = allocator.allocate(sizeBytes, queue);
+
+        // use a custom deleter to return the buffer to the CachingAllocator
+        auto deleter = [alloc = &allocator](TElem* ptr) { alloc->free(ptr); };
+
+        return alpaka::BufCpu<TElem, TDim, TIdx>(dev, reinterpret_cast<TElem*>(memPtr), std::move(deleter), extent);
+      }
+    };
+
+    //! The caching memory allocator implementation for the SYCL GPU device
+    template <typename TElem, typename TDim, typename TIdx, typename TQueue>
+    struct CachedBufAlloc<TElem, TDim, TIdx, alpaka::DevGpuSyclIntel, TQueue, void> {
+      template <typename TExtent>
+      ALPAKA_FN_HOST static auto allocCachedBuf(alpaka::DevGpuSyclIntel const& dev, TQueue queue, TExtent const& extent)
+          -> alpaka::BufGpuSyclIntel<TElem, TDim, TIdx> {
+        ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
+
+        auto& allocator = getDeviceCachingAllocator<alpaka::DevGpuSyclIntel, TQueue>(dev);
+
+        // TODO implement pitch for TDim > 1
+        size_t size = alpaka::getExtentProduct(extent);
+        size_t sizeBytes = size * sizeof(TElem);
+        void* memPtr = allocator.allocate(sizeBytes, queue);
+
+        // use a custom deleter to return the buffer to the CachingAllocator
+        auto deleter = [alloc = &allocator](TElem* ptr) { alloc->free(ptr); };
+
+        return alpaka::BufGpuSyclIntel<TElem, TDim, TIdx>(
+            dev, reinterpret_cast<TElem*>(memPtr), std::move(deleter), extent);
+      }
+    };
+
+#endif  // ALPAKA_SYCL_ONEAPI_GPU
+
   }  // namespace traits
 
   template <typename TElem, typename TIdx, typename TExtent, typename TQueue, typename TDev>

--- a/src/alpaka/AlpakaCore/CachingAllocator.h
+++ b/src/alpaka/AlpakaCore/CachingAllocator.h
@@ -124,7 +124,7 @@ namespace cms::alpakatools {
           maxCachedBytes_(cacheSize(maxCachedBytes, maxCachedFraction)),
           reuseSameQueueAllocations_(reuseSameQueueAllocations),
           debug_(debug) {
-      if constexpr (false) {
+      if (debug_) {
         std::ostringstream out;
         out << "CachingAllocator settings\n"
             << "  bin growth " << binGrowth_ << "\n"
@@ -197,24 +197,32 @@ namespace cms::alpakatools {
         // TODO use std::move ?
         cachedBlocks_.insert(std::make_pair(block.bin, block));
 
-        if constexpr (false) {
+        if (debug_) {
           std::ostringstream out;
           out << "\t" << deviceType_ << " " << alpaka::getName(device_) << " returned " << block.bytes << " bytes at "
-              << ptr << " from associated queue " << block.queue->getNativeHandle() << " , event "
-              << block.event->getNativeHandle() << " .\n\t\t " << cachedBlocks_.size() << " available blocks cached ("
-              << cachedBytes_.free << " bytes), " << liveBlocks_.size() << " live blocks (" << cachedBytes_.live
-              << " bytes) outstanding." << std::endl;
+              << ptr << " from associated queue " << block.queue->m_spQueueImpl.get() << " , event "
+#if ALPAKA_ACC_SYCL_ENABLED
+              << " is not a shared pointer in SYCL"
+#else
+              << block.event->m_spEventImpl.get()
+#endif
+              << " .\n\t\t " << cachedBlocks_.size() << " available blocks cached (" << cachedBytes_.free << " bytes), "
+              << liveBlocks_.size() << " live blocks (" << cachedBytes_.live << " bytes) outstanding." << std::endl;
           std::cout << out.str() << std::endl;
         }
       } else {
         // if the buffer is not recached, it is automatically freed when block goes out of scope
-        if constexpr (false) {
+        if (debug_) {
           std::ostringstream out;
           out << "\t" << deviceType_ << " " << alpaka::getName(device_) << " freed " << block.bytes << " bytes at "
-              << ptr << " from associated queue " << block.queue->getNativeHandle() << ", event "
-              << block.event->getNativeHandle() << " .\n\t\t " << cachedBlocks_.size() << " available blocks cached ("
-              << cachedBytes_.free << " bytes), " << liveBlocks_.size() << " live blocks (" << cachedBytes_.live
-              << " bytes) outstanding." << std::endl;
+              << ptr << " from associated queue " << block.queue->m_spQueueImpl.get() << ", event "
+#if ALPAKA_ACC_SYCL_ENABLED
+              << " is not a shared pointer in SYCL"
+#else
+              << block.event->m_spEventImpl.get()
+#endif
+              << " .\n\t\t " << cachedBlocks_.size() << " available blocks cached (" << cachedBytes_.free << " bytes), "
+              << liveBlocks_.size() << " live blocks (" << cachedBytes_.live << " bytes) outstanding." << std::endl;
           std::cout << out.str() << std::endl;
         }
       }
@@ -297,13 +305,23 @@ namespace cms::alpakatools {
           cachedBytes_.live += block.bytes;
           cachedBytes_.requested += block.requested;
 
-          if constexpr (false) {
+          if (debug_) {
             std::ostringstream out;
             out << "\t" << deviceType_ << " " << alpaka::getName(device_) << " reused cached block at "
-                << block.buffer->data() << " (" << block.bytes << " bytes) for queue " << block.queue->getNativeHandle()
-                << ", event " << block.event->getNativeHandle() << " (previously associated with stream "
-                << iBlock->second.queue->getNativeHandle() << " , event " << iBlock->second.event->getNativeHandle()
-                << ")." << std::endl;
+                << block.buffer->data() << " (" << block.bytes << " bytes) for queue "
+                << block.queue->m_spQueueImpl.get() << ", event "
+                <<
+#if ALPAKA_ACC_SYCL_ENABLED
+                " is not a shared pointer in SYCL"
+#else
+                block.event->m_spEventImpl.get()
+#endif
+                << " (previously associated with stream " << iBlock->second.queue->m_spQueueImpl.get() << " , event "
+#if ALPAKA_ACC_SYCL_ENABLED
+                << " is not a shared pointer in SYCL)." << std::endl;
+#else
+                << iBlock->second.event->m_spEventImpl.get() << ")." << std::endl;
+#endif
             std::cout << out.str() << std::endl;
           }
 
@@ -322,7 +340,8 @@ namespace cms::alpakatools {
         return alpaka::allocBuf<std::byte, size_t>(device_, bytes);
       } else if constexpr (std::is_same_v<Device, alpaka::DevCpu>) {
         // allocate pinned host memory accessible by the queue's platform
-        return alpaka::allocMappedBuf<alpaka::Pltf<alpaka::Dev<Queue>>, std::byte, size_t>(device_, bytes);
+        return alpaka::allocMappedBuf<alpaka::Platform<alpaka::Dev<Queue>>, std::byte, size_t>(
+            device_, *platform, bytes);
       } else {
         // unsupported combination
         static_assert(std::is_same_v<Device, alpaka::Dev<Queue>> or std::is_same_v<Device, alpaka::DevCpu>,
@@ -336,11 +355,11 @@ namespace cms::alpakatools {
         block.buffer = allocateBuffer(block.bytes, *block.queue);
       } catch (std::runtime_error const& e) {
         // the allocation attempt failed: free all cached blocks on the device and retry
-        if constexpr (false) {
+        if (debug_) {
           std::ostringstream out;
           out << "\t" << deviceType_ << " " << alpaka::getName(device_) << " failed to allocate " << block.bytes
-              << " bytes for queue " << block.queue->getNativeHandle() << ", retrying after freeing cached allocations"
-              << std::endl;
+              << " bytes for queue " << block.queue->m_spQueueImpl.get()
+              << ", retrying after freeing cached allocations" << std::endl;
           std::cout << out.str() << std::endl;
         }
         // TODO implement a method that frees only up to block.bytes bytes
@@ -361,11 +380,18 @@ namespace cms::alpakatools {
         liveBlocks_[block.buffer->data()] = block;
       }
 
-      if constexpr (false) {
+      if (debug_) {
         std::ostringstream out;
         out << "\t" << deviceType_ << " " << alpaka::getName(device_) << " allocated new block at "
             << block.buffer->data() << " (" << block.bytes << " bytes associated with queue "
-            << block.queue->getNativeHandle() << ", event " << block.event->getNativeHandle() << "." << std::endl;
+            << block.queue->m_spQueueImpl.get() << ", event "
+            <<
+#if ALPAKA_ACC_SYCL_ENABLED
+            " is not a shared pointer in SYCL"
+#else
+            block.event->m_spEventImpl.get()
+#endif
+            << "." << std::endl;
         std::cout << out.str() << std::endl;
       }
     }
@@ -377,7 +403,7 @@ namespace cms::alpakatools {
         auto iBlock = cachedBlocks_.begin();
         cachedBytes_.free -= iBlock->second.bytes;
 
-        if constexpr (false) {
+        if (debug_) {
           std::ostringstream out;
           out << "\t" << deviceType_ << " " << alpaka::getName(device_) << " freed " << iBlock->second.bytes
               << " bytes.\n\t\t  " << (cachedBlocks_.size() - 1) << " available blocks cached (" << cachedBytes_.free

--- a/src/alpaka/AlpakaCore/CachingAllocator.h
+++ b/src/alpaka/AlpakaCore/CachingAllocator.h
@@ -124,7 +124,7 @@ namespace cms::alpakatools {
           maxCachedBytes_(cacheSize(maxCachedBytes, maxCachedFraction)),
           reuseSameQueueAllocations_(reuseSameQueueAllocations),
           debug_(debug) {
-      if (debug_) {
+      if constexpr (false) {
         std::ostringstream out;
         out << "CachingAllocator settings\n"
             << "  bin growth " << binGrowth_ << "\n"
@@ -197,22 +197,22 @@ namespace cms::alpakatools {
         // TODO use std::move ?
         cachedBlocks_.insert(std::make_pair(block.bin, block));
 
-        if (debug_) {
+        if constexpr (false) {
           std::ostringstream out;
           out << "\t" << deviceType_ << " " << alpaka::getName(device_) << " returned " << block.bytes << " bytes at "
-              << ptr << " from associated queue " << block.queue->m_spQueueImpl.get() << " , event "
-              << block.event->m_spEventImpl.get() << " .\n\t\t " << cachedBlocks_.size() << " available blocks cached ("
+              << ptr << " from associated queue " << block.queue->getNativeHandle() << " , event "
+              << block.event->getNativeHandle() << " .\n\t\t " << cachedBlocks_.size() << " available blocks cached ("
               << cachedBytes_.free << " bytes), " << liveBlocks_.size() << " live blocks (" << cachedBytes_.live
               << " bytes) outstanding." << std::endl;
           std::cout << out.str() << std::endl;
         }
       } else {
         // if the buffer is not recached, it is automatically freed when block goes out of scope
-        if (debug_) {
+        if constexpr (false) {
           std::ostringstream out;
           out << "\t" << deviceType_ << " " << alpaka::getName(device_) << " freed " << block.bytes << " bytes at "
-              << ptr << " from associated queue " << block.queue->m_spQueueImpl.get() << ", event "
-              << block.event->m_spEventImpl.get() << " .\n\t\t " << cachedBlocks_.size() << " available blocks cached ("
+              << ptr << " from associated queue " << block.queue->getNativeHandle() << ", event "
+              << block.event->getNativeHandle() << " .\n\t\t " << cachedBlocks_.size() << " available blocks cached ("
               << cachedBytes_.free << " bytes), " << liveBlocks_.size() << " live blocks (" << cachedBytes_.live
               << " bytes) outstanding." << std::endl;
           std::cout << out.str() << std::endl;
@@ -297,13 +297,13 @@ namespace cms::alpakatools {
           cachedBytes_.live += block.bytes;
           cachedBytes_.requested += block.requested;
 
-          if (debug_) {
+          if constexpr (false) {
             std::ostringstream out;
             out << "\t" << deviceType_ << " " << alpaka::getName(device_) << " reused cached block at "
-                << block.buffer->data() << " (" << block.bytes << " bytes) for queue "
-                << block.queue->m_spQueueImpl.get() << ", event " << block.event->m_spEventImpl.get()
-                << " (previously associated with stream " << iBlock->second.queue->m_spQueueImpl.get() << " , event "
-                << iBlock->second.event->m_spEventImpl.get() << ")." << std::endl;
+                << block.buffer->data() << " (" << block.bytes << " bytes) for queue " << block.queue->getNativeHandle()
+                << ", event " << block.event->getNativeHandle() << " (previously associated with stream "
+                << iBlock->second.queue->getNativeHandle() << " , event " << iBlock->second.event->getNativeHandle()
+                << ")." << std::endl;
             std::cout << out.str() << std::endl;
           }
 
@@ -336,11 +336,11 @@ namespace cms::alpakatools {
         block.buffer = allocateBuffer(block.bytes, *block.queue);
       } catch (std::runtime_error const& e) {
         // the allocation attempt failed: free all cached blocks on the device and retry
-        if (debug_) {
+        if constexpr (false) {
           std::ostringstream out;
           out << "\t" << deviceType_ << " " << alpaka::getName(device_) << " failed to allocate " << block.bytes
-              << " bytes for queue " << block.queue->m_spQueueImpl.get()
-              << ", retrying after freeing cached allocations" << std::endl;
+              << " bytes for queue " << block.queue->getNativeHandle() << ", retrying after freeing cached allocations"
+              << std::endl;
           std::cout << out.str() << std::endl;
         }
         // TODO implement a method that frees only up to block.bytes bytes
@@ -361,11 +361,11 @@ namespace cms::alpakatools {
         liveBlocks_[block.buffer->data()] = block;
       }
 
-      if (debug_) {
+      if constexpr (false) {
         std::ostringstream out;
         out << "\t" << deviceType_ << " " << alpaka::getName(device_) << " allocated new block at "
             << block.buffer->data() << " (" << block.bytes << " bytes associated with queue "
-            << block.queue->m_spQueueImpl.get() << ", event " << block.event->m_spEventImpl.get() << "." << std::endl;
+            << block.queue->getNativeHandle() << ", event " << block.event->getNativeHandle() << "." << std::endl;
         std::cout << out.str() << std::endl;
       }
     }
@@ -377,7 +377,7 @@ namespace cms::alpakatools {
         auto iBlock = cachedBlocks_.begin();
         cachedBytes_.free -= iBlock->second.bytes;
 
-        if (debug_) {
+        if constexpr (false) {
           std::ostringstream out;
           out << "\t" << deviceType_ << " " << alpaka::getName(device_) << " freed " << iBlock->second.bytes
               << " bytes.\n\t\t  " << (cachedBlocks_.size() - 1) << " available blocks cached (" << cachedBytes_.free

--- a/src/alpaka/AlpakaCore/EventCache.h
+++ b/src/alpaka/AlpakaCore/EventCache.h
@@ -7,8 +7,7 @@
 
 #include <alpaka/alpaka.hpp>
 
-#include "AlpakaCore/alpakaConfig.h"
-#include "AlpakaCore/getDeviceIndex.h"
+#include "AlpakaCore/alpakaDevices.h"
 #include "Framework/ReusableObjectHolder.h"
 
 namespace cms::alpakatools {
@@ -17,11 +16,11 @@ namespace cms::alpakatools {
   class EventCache {
   public:
     using Device = alpaka::Dev<Event>;
-    using Platform = alpaka::Pltf<Device>;
+    using Platform = alpaka::Platform<Device>;
 
     // EventCache should be constructed by the first call to
     // getEventCache() only if we have CUDA devices present
-    EventCache() : cache_(alpaka::getDevCount<Platform>()) {}
+    EventCache() : cache_(alpaka::getDevCount(*platform)) {}
 
     // Gets a (cached) CUDA event for the current device. The event
     // will be returned to the cache by the shared_ptr destructor. The
@@ -66,7 +65,7 @@ namespace cms::alpakatools {
       // EventCache lives through multiple tests (and go through
       // multiple shutdowns of the framework).
       cache_.clear();
-      cache_.resize(alpaka::getDevCount<Platform>());
+      cache_.resize(alpaka::getDevCount(*platform));
     }
 
     std::vector<edm::ReusableObjectHolder<Event>> cache_;

--- a/src/alpaka/AlpakaCore/HostOnlyTask.h
+++ b/src/alpaka/AlpakaCore/HostOnlyTask.h
@@ -65,8 +65,8 @@ namespace alpaka {
     using Task = std::packaged_task<void()>;
     //! The SYCL CPU async queue enqueue trait specialization for "safe tasks"
     template <>
-    struct Enqueue<QueueCpuSyclIntelNonBlocking, Task> {
-      ALPAKA_FN_HOST static auto enqueue(QueueCpuSyclIntelNonBlocking& queue, Task&& task) -> void {
+    struct Enqueue<QueueCpuSyclNonBlocking, Task> {
+      ALPAKA_FN_HOST static auto enqueue(QueueCpuSyclNonBlocking& queue, Task&& task) -> void {
         alpaka::core::CallbackThread m_callbackThread;
         queue.getNativeHandle().wait();
         m_callbackThread.submit(std::forward<Task>(task));

--- a/src/alpaka/AlpakaCore/ScopedContext.h
+++ b/src/alpaka/AlpakaCore/ScopedContext.h
@@ -30,7 +30,7 @@ namespace cms::alpakatools {
     public:
       using Queue = TQueue;
       using Device = alpaka::Dev<Queue>;
-      using Platform = alpaka::Pltf<Device>;
+      using Platform = alpaka::Platform<Device>;
 
       Device device() const { return alpaka::getDev(*stream_); }
 

--- a/src/alpaka/AlpakaCore/ScopedContext.h
+++ b/src/alpaka/AlpakaCore/ScopedContext.h
@@ -216,13 +216,34 @@ namespace cms::alpakatools {
 
     /// Constructor to re-use the CUDA stream of acquire() (ExternalWork module)
     explicit ScopedContextProduce(ContextState<Queue>& state)
-        : ScopedContextGetterBase(state.releaseStreamPtr()), event_{getEventCache<Event>().get(device())} {}
+#if defined(ALPAKA_ACC_SYCL_ENABLED)
+        : ScopedContextGetterBase(state.releaseStreamPtr()), event_{std::make_shared<Event>(device())} {
+      event_->setEvent(stream().getNativeHandle().submit_barrier());
+    }
+#else
+        : ScopedContextGetterBase(state.releaseStreamPtr()), event_{getEventCache<Event>().get(device())} {
+    }
+#endif
 
     explicit ScopedContextProduce(ProductBase<Queue> const& data)
-        : ScopedContextGetterBase(data), event_{getEventCache<Event>().get(device())} {}
+#if defined(ALPAKA_ACC_SYCL_ENABLED)
+        : ScopedContextGetterBase(data), event_{std::make_shared<Event>(device())} {
+      event_->setEvent(stream().getNativeHandle().submit_barrier());
+    }
+#else
+        : ScopedContextGetterBase(data), event_{getEventCache<Event>().get(device())} {
+    }
+#endif
 
     explicit ScopedContextProduce(edm::StreamID streamID)
-        : ScopedContextGetterBase(streamID), event_{getEventCache<Event>().get(device())} {}
+#if defined(ALPAKA_ACC_SYCL_ENABLED)
+        : ScopedContextGetterBase(streamID), event_{std::make_shared<Event>(device())} {
+      event_->setEvent(stream().getNativeHandle().submit_barrier());
+    }
+#else
+        : ScopedContextGetterBase(streamID), event_{getEventCache<Event>().get(device())} {
+    }
+#endif
 
     /// Record the event, all asynchronous work must have been queued before the destructor
     ~ScopedContextProduce() {

--- a/src/alpaka/AlpakaCore/StreamCache.h
+++ b/src/alpaka/AlpakaCore/StreamCache.h
@@ -4,8 +4,9 @@
 #include <memory>
 #include <vector>
 
-#include "AlpakaCore/alpakaConfig.h"
-#include "AlpakaCore/getDeviceIndex.h"
+//#include "AlpakaCore/alpakaConfig.h"
+//#include "AlpakaCore/getDeviceIndex.h"
+#include "AlpakaCore/alpakaDevices.h"
 #include "Framework/ReusableObjectHolder.h"
 
 namespace cms::alpakatools {
@@ -13,12 +14,12 @@ namespace cms::alpakatools {
   template <typename Queue>
   class StreamCache {
     using Device = alpaka::Dev<Queue>;
-    using Platform = alpaka::Pltf<Device>;
+    using Platform = alpaka::Platform<Device>;
 
   public:
     // StreamCache should be constructed by the first call to
     // getStreamCache() only if we have CUDA devices present
-    StreamCache() : cache_(alpaka::getDevCount<Platform>()) {}
+    StreamCache() : cache_(alpaka::getDevCount(*cms::alpakatools::platform)) {}
 
     // Gets a (cached) CUDA stream for the current device. The stream
     // will be returned to the cache by the shared_ptr destructor.
@@ -36,7 +37,7 @@ namespace cms::alpakatools {
       // StreamCache lives through multiple tests (and go through
       // multiple shutdowns of the framework).
       cache_.clear();
-      cache_.resize(alpaka::getDevCount<Platform>());
+      cache_.resize(alpaka::getDevCount(*cms::alpakatools::platform));
     }
 
     std::vector<edm::ReusableObjectHolder<Queue>> cache_;

--- a/src/alpaka/AlpakaCore/alpaka/initialise.cc
+++ b/src/alpaka/AlpakaCore/alpaka/initialise.cc
@@ -29,4 +29,17 @@ namespace cms::alpakatools {
   // explicit template instantiation definition
   template void initialise<ALPAKA_ACCELERATOR_NAMESPACE::Platform>();
 
+  template <typename TPlatform>
+  void resetDevices() {
+#ifdef ALPAKA_ACC_SYCL_ENABLED
+    devices<TPlatform>.clear();
+    TPlatform::reset();
+#else
+    devices<TPlatform>.clear();
+#endif
+  }
+
+  // explicit template instantiation definition
+  template void resetDevices<ALPAKA_ACCELERATOR_NAMESPACE::Platform>();
+
 }  // namespace cms::alpakatools

--- a/src/alpaka/AlpakaCore/alpaka/initialise.cc
+++ b/src/alpaka/AlpakaCore/alpaka/initialise.cc
@@ -4,6 +4,7 @@
 
 #include "AlpakaCore/alpakaConfig.h"
 #include "AlpakaCore/alpakaDevices.h"
+#include "AlpakaCore/getDeviceIndex.h"
 #include "AlpakaCore/initialise.h"
 #include "Framework/demangle.h"
 
@@ -16,27 +17,23 @@ namespace cms::alpakatools {
     if (devices<TPlatform>.empty()) {
       devices<TPlatform> = enumerate<TPlatform>();
       auto size = devices<TPlatform>.size();
-      //std::cout << edm::demangle<TPlatform> << " platform succesfully initialised." << std::endl;
+      // std::cout << edm::demangle<TPlatform> << " platform succesfully initialised." << std::endl;
       std::cout << "Found " << size << " " << suffix[size < 2 ? size : 2] << std::endl;
       for (auto const& device : devices<TPlatform>) {
         std::cout << "  - " << alpaka::getName(device) << std::endl;
       }
     } else {
-      //std::cout << edm::demangle<TPlatform> << " platform already initialised." << std::endl;
+      // std::cout << edm::demangle<TPlatform> << " platform already initialised." << std::endl;
     }
   }
 
   // explicit template instantiation definition
   template void initialise<ALPAKA_ACCELERATOR_NAMESPACE::Platform>();
 
-  template <typename TPlatform>
+  template<typename TPlatform>
   void resetDevices() {
-#ifdef ALPAKA_ACC_SYCL_ENABLED
     devices<TPlatform>.clear();
-    TPlatform::reset();
-#else
-    devices<TPlatform>.clear();
-#endif
+    platform.reset();
   }
 
   // explicit template instantiation definition

--- a/src/alpaka/AlpakaCore/alpakaConfig.h
+++ b/src/alpaka/AlpakaCore/alpakaConfig.h
@@ -88,6 +88,49 @@ namespace alpaka_rocm_async {
 #define ALPAKA_ACCELERATOR_NAMESPACE alpaka_rocm_async
 #endif  // ALPAKA_ACC_GPU_HIP_ASYNC_BACKEND
 
+#ifdef ALPAKA_ACC_SYCL_PRESENT
+namespace alpaka_cpu_sycl {
+  using namespace alpaka_common;
+
+  using Platform = alpaka::PltfCpuSyclIntel;
+  using Device = alpaka::DevCpuSyclIntel;
+  using Queue = alpaka::QueueCpuSyclIntelNonBlocking;
+  using Event = alpaka::EventCpuSyclIntel;
+
+  template <typename TDim>
+  using Acc = alpaka::AccCpuSyclIntel<TDim, Idx>;
+  using Acc1D = Acc<Dim1D>;
+  using Acc2D = Acc<Dim2D>;
+  using Acc3D = Acc<Dim3D>;
+
+}  // namespace alpaka_cpu_sycl
+
+namespace alpaka_gpu_sycl {
+  using namespace alpaka_common;
+
+  using Platform = alpaka::PltfGpuSyclIntel;
+  using Device = alpaka::DevGpuSyclIntel;
+  using Queue = alpaka::QueueGpuSyclIntelNonBlocking;
+  using Event = alpaka::EventGpuSyclIntel;
+
+  template <typename TDim>
+  using Acc = alpaka::AccGpuSyclIntel<TDim, Idx>;
+  using Acc1D = Acc<Dim1D>;
+  using Acc2D = Acc<Dim2D>;
+  using Acc3D = Acc<Dim3D>;
+
+}  // namespace alpaka_gpu_sycl
+
+#endif  // ALPAKA_ACC_SYCL_PRESENT
+
+#ifdef ALPAKA_SYCL_ONEAPI_CPU
+#define ALPAKA_ACCELERATOR_NAMESPACE alpaka_cpu_sycl
+#endif  // ALPAKA_SYCL_ONEAPI_CPU
+
+#ifdef ALPAKA_SYCL_ONEAPI_GPU
+#define ALPAKA_ACCELERATOR_NAMESPACE alpaka_gpu_sycl
+#endif  // ALPAKA_SYCL_ONEAPI_GPU
+
 #ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_PRESENT
 namespace alpaka_serial_sync {
   using namespace alpaka_common;

--- a/src/alpaka/AlpakaCore/alpakaConfig.h
+++ b/src/alpaka/AlpakaCore/alpakaConfig.h
@@ -92,13 +92,13 @@ namespace alpaka_rocm_async {
 namespace alpaka_cpu_sycl {
   using namespace alpaka_common;
 
-  using Platform = alpaka::PltfCpuSyclIntel;
-  using Device = alpaka::DevCpuSyclIntel;
-  using Queue = alpaka::QueueCpuSyclIntelNonBlocking;
-  using Event = alpaka::EventCpuSyclIntel;
+  using Platform = alpaka::PltfCpuSycl;
+  using Device = alpaka::DevCpuSycl;
+  using Queue = alpaka::QueueCpuSyclNonBlocking;
+  using Event = alpaka::EventCpuSycl;
 
   template <typename TDim>
-  using Acc = alpaka::AccCpuSyclIntel<TDim, Idx>;
+  using Acc = alpaka::AccCpuSycl<TDim, Idx>;
   using Acc1D = Acc<Dim1D>;
   using Acc2D = Acc<Dim2D>;
   using Acc3D = Acc<Dim3D>;

--- a/src/alpaka/AlpakaCore/alpakaConfig.h
+++ b/src/alpaka/AlpakaCore/alpakaConfig.h
@@ -30,7 +30,7 @@ namespace alpaka_common {
 
   // host types
   using DevHost = alpaka::DevCpu;
-  using PltfHost = alpaka::PltfCpu;
+  using PlatformHost = alpaka::PlatformCpu;
 
 }  // namespace alpaka_common
 
@@ -46,7 +46,7 @@ namespace alpaka_common {
 namespace alpaka_cuda_async {
   using namespace alpaka_common;
 
-  using Platform = alpaka::PltfCudaRt;
+  using Platform = alpaka::PlatformCudaRt;
   using Device = alpaka::DevCudaRt;
   using Queue = alpaka::QueueCudaRtNonBlocking;
   using Event = alpaka::EventCudaRt;
@@ -69,7 +69,7 @@ namespace alpaka_cuda_async {
 namespace alpaka_rocm_async {
   using namespace alpaka_common;
 
-  using Platform = alpaka::PltfHipRt;
+  using Platform = alpaka::PlatformHipRt;
   using Device = alpaka::DevHipRt;
   using Queue = alpaka::QueueHipRtNonBlocking;
   using Event = alpaka::EventHipRt;
@@ -92,7 +92,7 @@ namespace alpaka_rocm_async {
 namespace alpaka_cpu_sycl {
   using namespace alpaka_common;
 
-  using Platform = alpaka::PltfCpuSycl;
+  using Platform = alpaka::PlatformCpuSycl;
   using Device = alpaka::DevCpuSycl;
   using Queue = alpaka::QueueCpuSyclNonBlocking;
   using Event = alpaka::EventCpuSycl;
@@ -108,7 +108,7 @@ namespace alpaka_cpu_sycl {
 namespace alpaka_gpu_sycl {
   using namespace alpaka_common;
 
-  using Platform = alpaka::PltfGpuSyclIntel;
+  using Platform = alpaka::PlatformGpuSyclIntel;
   using Device = alpaka::DevGpuSyclIntel;
   using Queue = alpaka::QueueGpuSyclIntelNonBlocking;
   using Event = alpaka::EventGpuSyclIntel;
@@ -135,7 +135,7 @@ namespace alpaka_gpu_sycl {
 namespace alpaka_serial_sync {
   using namespace alpaka_common;
 
-  using Platform = alpaka::PltfCpu;
+  using Platform = alpaka::PlatformCpu;
   using Device = alpaka::DevCpu;
   using Queue = alpaka::QueueCpuBlocking;
   using Event = alpaka::EventCpu;
@@ -158,7 +158,7 @@ namespace alpaka_serial_sync {
 namespace alpaka_tbb_async {
   using namespace alpaka_common;
 
-  using Platform = alpaka::PltfCpu;
+  using Platform = alpaka::PlatformCpu;
   using Device = alpaka::DevCpu;
   using Queue = alpaka::QueueCpuNonBlocking;
   using Event = alpaka::EventCpu;
@@ -181,7 +181,7 @@ namespace alpaka_tbb_async {
 namespace alpaka_omp2_async {
   using namespace alpaka_common;
 
-  using Platform = alpaka::PltfCpu;
+  using Platform = alpaka::PlatformCpu;
   using Device = alpaka::DevCpu;
   using Queue = alpaka::QueueCpuBlocking;
   using Event = alpaka::EventCpu;

--- a/src/alpaka/AlpakaCore/alpakaDevices.h
+++ b/src/alpaka/AlpakaCore/alpakaDevices.h
@@ -12,7 +12,8 @@
 namespace cms::alpakatools {
 
   // alpaka host device
-  inline const alpaka_common::DevHost host = alpaka::getDevByIdx<alpaka_common::PltfHost>(0u);
+  inline const alpaka_common::PlatformHost platformHost{};
+  inline const alpaka_common::DevHost host = alpaka::getDevByIdx(platformHost, 0u);
 
   // alpaka accelerator devices
   template <typename TPlatform>
@@ -24,12 +25,13 @@ namespace cms::alpakatools {
 
     using Device = alpaka::Dev<TPlatform>;
     using Platform = TPlatform;
+    platform = Platform{};
 
     std::vector<Device> devices;
-    uint32_t n = alpaka::getDevCount<Platform>();
+    uint32_t n = alpaka::getDevCount(*platform);
     devices.reserve(n);
     for (uint32_t i = 0; i < n; ++i) {
-      devices.push_back(alpaka::getDevByIdx<Platform>(i));
+      devices.push_back(alpaka::getDevByIdx(*platform, i));
       assert(getDeviceIndex(devices.back()) == static_cast<int>(i));
     }
     return devices;

--- a/src/alpaka/AlpakaCore/alpakaFwd.h
+++ b/src/alpaka/AlpakaCore/alpakaFwd.h
@@ -31,7 +31,7 @@ namespace alpaka {
   struct ApiHipRt;
 
   namespace detail {
-    struct IntelCpuSelector;
+    struct SyclCpuSelector;
     struct IntelGpuSelector;
   }  // namespace detail
 
@@ -43,7 +43,7 @@ namespace alpaka {
   using PltfHipRt = PltfUniformCudaHipRt<ApiHipRt>;
   template <typename TSelector>
   class PltfGenericSycl;
-  using PltfCpuSyclIntel = PltfGenericSycl<detail::IntelCpuSelector>;
+  using PltfCpuSycl = PltfGenericSycl<detail::SyclCpuSelector>;
   using PltfGpuSyclIntel = PltfGenericSycl<detail::IntelGpuSelector>;
 
   // Devices
@@ -54,7 +54,7 @@ namespace alpaka {
   using DevHipRt = DevUniformCudaHipRt<ApiHipRt>;
   template <typename TPltf>
   class DevGenericSycl;
-  using DevCpuSyclIntel = DevGenericSycl<PltfCpuSyclIntel>;
+  using DevCpuSycl = DevGenericSycl<PltfCpuSycl>;
   using DevGpuSyclIntel = DevGenericSycl<PltfGpuSyclIntel>;
 
   // Queues
@@ -75,13 +75,19 @@ namespace alpaka {
   using QueueHipRtBlocking = uniform_cuda_hip::detail::QueueUniformCudaHipRt<ApiHipRt, true>;
   using QueueHipRtNonBlocking = uniform_cuda_hip::detail::QueueUniformCudaHipRt<ApiHipRt, false>;
 
-  template <typename TDev, bool TBlocking>
-  class QueueGenericSyclBase;
+  namespace detail {
+    template <typename TDev, bool TBlocking>
+    class QueueGenericSyclBase;
+  }
+  template <typename TDev>
+  using QueueGenericSyclBlocking = detail::QueueGenericSyclBase<TDev, true>;
+  template <typename TDev>
+  using QueueGenericSyclNonBlocking = detail::QueueGenericSyclBase<TDev, false>;
 
-  using QueueCpuSyclIntelBlocking = QueueGenericSyclBase<DevCpuSyclIntel, true>;
-  using QueueCpuSyclIntelNonBlocking = QueueGenericSyclBase<DevCpuSyclIntel, false>;
-  using QueueGpuSyclIntelBlocking = QueueGenericSyclBase<DevGpuSyclIntel, true>;
-  using QueueGpuSyclIntelNonBlocking = QueueGenericSyclBase<DevGpuSyclIntel, false>;
+  using QueueCpuSyclBlocking = QueueGenericSyclBlocking<DevCpuSycl>;
+  using QueueCpuSyclNonBlocking = QueueGenericSyclNonBlocking<DevCpuSycl>;
+  using QueueGpuSyclIntelBlocking = QueueGenericSyclBlocking<DevGpuSyclIntel>;
+  using QueueGpuSyclIntelNonBlocking = QueueGenericSyclNonBlocking<DevGpuSyclIntel>;
 
   // Events
   template <typename TDev>
@@ -95,7 +101,7 @@ namespace alpaka {
 
   template <typename TDev>
   class EventGenericSycl;
-  using EventCpuSyclIntel = EventGenericSycl<DevCpuSyclIntel>;
+  using EventCpuSycl = EventGenericSycl<DevCpuSycl>;
   using EventGpuSyclIntel = EventGenericSycl<DevGpuSyclIntel>;
 
   // Accelerators
@@ -118,7 +124,7 @@ namespace alpaka {
   class AccCpuOmp2Blocks;
 
   template <typename TDim, typename TIdx>
-  class AccCpuSyclIntel;
+  class AccCpuSycl;
 
   template <typename TDim, typename TIdx>
   class AccGpuSyclIntel;

--- a/src/alpaka/AlpakaCore/alpakaFwd.h
+++ b/src/alpaka/AlpakaCore/alpakaFwd.h
@@ -36,15 +36,15 @@ namespace alpaka {
   }  // namespace detail
 
   // Platforms
-  class PltfCpu;
+  class PlatformCpu;
   template <typename TApi>
-  class PltfUniformCudaHipRt;
-  using PltfCudaRt = PltfUniformCudaHipRt<ApiCudaRt>;
-  using PltfHipRt = PltfUniformCudaHipRt<ApiHipRt>;
+  class PlatformUniformCudaHipRt;
+  using PlatformCudaRt = PlatformUniformCudaHipRt<ApiCudaRt>;
+  using PlatformHipRt = PlatformUniformCudaHipRt<ApiHipRt>;
   template <typename TSelector>
-  class PltfGenericSycl;
-  using PltfCpuSycl = PltfGenericSycl<detail::SyclCpuSelector>;
-  using PltfGpuSyclIntel = PltfGenericSycl<detail::IntelGpuSelector>;
+  class PlatformGenericSycl;
+  using PlatformCpuSycl = PlatformGenericSycl<detail::SyclCpuSelector>;
+  using PlatformGpuSyclIntel = PlatformGenericSycl<detail::IntelGpuSelector>;
 
   // Devices
   class DevCpu;
@@ -52,10 +52,10 @@ namespace alpaka {
   class DevUniformCudaHipRt;
   using DevCudaRt = DevUniformCudaHipRt<ApiCudaRt>;
   using DevHipRt = DevUniformCudaHipRt<ApiHipRt>;
-  template <typename TPltf>
+  template <typename TPlatform>
   class DevGenericSycl;
-  using DevCpuSycl = DevGenericSycl<PltfCpuSycl>;
-  using DevGpuSyclIntel = DevGenericSycl<PltfGpuSyclIntel>;
+  using DevCpuSycl = DevGenericSycl<PlatformCpuSycl>;
+  using DevGpuSyclIntel = DevGenericSycl<PlatformGpuSyclIntel>;
 
   // Queues
   template <typename TDev>

--- a/src/alpaka/AlpakaCore/alpakaFwd.h
+++ b/src/alpaka/AlpakaCore/alpakaFwd.h
@@ -30,12 +30,21 @@ namespace alpaka {
   struct ApiCudaRt;
   struct ApiHipRt;
 
+  namespace detail {
+    struct IntelCpuSelector;
+    struct IntelGpuSelector;
+  }  // namespace detail
+
   // Platforms
   class PltfCpu;
   template <typename TApi>
   class PltfUniformCudaHipRt;
   using PltfCudaRt = PltfUniformCudaHipRt<ApiCudaRt>;
   using PltfHipRt = PltfUniformCudaHipRt<ApiHipRt>;
+  template <typename TSelector>
+  class PltfGenericSycl;
+  using PltfCpuSyclIntel = PltfGenericSycl<detail::IntelCpuSelector>;
+  using PltfGpuSyclIntel = PltfGenericSycl<detail::IntelGpuSelector>;
 
   // Devices
   class DevCpu;
@@ -43,6 +52,10 @@ namespace alpaka {
   class DevUniformCudaHipRt;
   using DevCudaRt = DevUniformCudaHipRt<ApiCudaRt>;
   using DevHipRt = DevUniformCudaHipRt<ApiHipRt>;
+  template <typename TPltf>
+  class DevGenericSycl;
+  using DevCpuSyclIntel = DevGenericSycl<PltfCpuSyclIntel>;
+  using DevGpuSyclIntel = DevGenericSycl<PltfGpuSyclIntel>;
 
   // Queues
   template <typename TDev>
@@ -62,6 +75,14 @@ namespace alpaka {
   using QueueHipRtBlocking = uniform_cuda_hip::detail::QueueUniformCudaHipRt<ApiHipRt, true>;
   using QueueHipRtNonBlocking = uniform_cuda_hip::detail::QueueUniformCudaHipRt<ApiHipRt, false>;
 
+  template <typename TDev, bool TBlocking>
+  class QueueGenericSyclBase;
+
+  using QueueCpuSyclIntelBlocking = QueueGenericSyclBase<DevCpuSyclIntel, true>;
+  using QueueCpuSyclIntelNonBlocking = QueueGenericSyclBase<DevCpuSyclIntel, false>;
+  using QueueGpuSyclIntelBlocking = QueueGenericSyclBase<DevGpuSyclIntel, true>;
+  using QueueGpuSyclIntelNonBlocking = QueueGenericSyclBase<DevGpuSyclIntel, false>;
+
   // Events
   template <typename TDev>
   class EventGenericThreads;
@@ -71,6 +92,11 @@ namespace alpaka {
   class EventUniformCudaHipRt;
   using EventCudaRt = EventUniformCudaHipRt<ApiCudaRt>;
   using EventHipRt = EventUniformCudaHipRt<ApiHipRt>;
+
+  template <typename TDev>
+  class EventGenericSycl;
+  using EventCpuSyclIntel = EventGenericSycl<DevCpuSyclIntel>;
+  using EventGpuSyclIntel = EventGenericSycl<DevGpuSyclIntel>;
 
   // Accelerators
   template <typename TApi, typename TDim, typename TIdx>
@@ -90,6 +116,12 @@ namespace alpaka {
 
   template <typename TDim, typename TIdx>
   class AccCpuOmp2Blocks;
+
+  template <typename TDim, typename TIdx>
+  class AccCpuSyclIntel;
+
+  template <typename TDim, typename TIdx>
+  class AccGpuSyclIntel;
 
 }  // namespace alpaka
 

--- a/src/alpaka/AlpakaCore/alpakaMemory.h
+++ b/src/alpaka/AlpakaCore/alpakaMemory.h
@@ -104,7 +104,7 @@ namespace cms::alpakatools {
     if constexpr (allocator_policy<alpaka::Dev<TQueue>> == AllocatorPolicy::Caching) {
       return allocCachedBuf<T, Idx>(host, queue, Scalar{});
     } else {
-      return alpaka::allocMappedBuf<T, Idx>(host, alpaka::getDev(queue), Scalar{});
+      return alpaka::allocMappedBuf<alpaka::Pltf<alpaka::Dev<TQueue>>, T, Idx>(host, Scalar{});
     }
   }
 
@@ -114,7 +114,8 @@ namespace cms::alpakatools {
     if constexpr (allocator_policy<alpaka::Dev<TQueue>> == AllocatorPolicy::Caching) {
       return allocCachedBuf<std::remove_extent_t<T>, Idx>(host, queue, Vec1D{extent});
     } else {
-      return alpaka::allocMappedBuf<std::remove_extent_t<T>, Idx>(host, alpaka::getDev(queue), Vec1D{extent});
+      return alpaka::allocMappedBuf<alpaka::Pltf<alpaka::Dev<TQueue>>, std::remove_extent_t<T>, Idx>(host,
+                                                                                                     Vec1D{extent});
     }
   }
 
@@ -124,7 +125,8 @@ namespace cms::alpakatools {
     if constexpr (allocator_policy<alpaka::Dev<TQueue>> == AllocatorPolicy::Caching) {
       return allocCachedBuf<std::remove_extent_t<T>, Idx>(host, queue, Vec1D{std::extent_v<T>});
     } else {
-      return alpaka::allocMappedBuf<std::remove_extent_t<T>, Idx>(host, alpaka::getDev(queue), Vec1D{std::extent_v<T>});
+      return alpaka::allocMappedBuf<alpaka::Pltf<alpaka::Dev<TQueue>>, std::remove_extent_t<T>, Idx>(
+          host, Vec1D{std::extent_v<T>});
     }
   }
 

--- a/src/alpaka/AlpakaCore/alpakaMemory.h
+++ b/src/alpaka/AlpakaCore/alpakaMemory.h
@@ -96,6 +96,26 @@ namespace cms::alpakatools {
     return alpaka::allocBuf<std::remove_extent_t<T>, Idx>(host, Vec1D{std::extent_v<T>});
   }
 
+  // non-cached, pinned, scalar and 1-dimensional host buffers
+  // the memory is pinned according to the device associated to the platform
+
+  template <typename T, typename TPlatform>
+  std::enable_if_t<not std::is_array_v<T>, host_buffer<T>> make_host_buffer() {
+    return alpaka::allocMappedBuf<TPlatform, T, Idx>(host, *platform, Scalar{});
+  }
+
+  template <typename T, typename TPlatform>
+  std::enable_if_t<cms::is_unbounded_array_v<T> and not std::is_array_v<std::remove_extent_t<T>>, host_buffer<T>>
+  make_host_buffer(Extent extent) {
+    return alpaka::allocMappedBuf<TPlatform, std::remove_extent_t<T>, Idx>(host, *platform, Vec1D{extent});
+  }
+
+  template <typename T, typename TPlatform>
+  std::enable_if_t<cms::is_bounded_array_v<T> and not std::is_array_v<std::remove_extent_t<T>>, host_buffer<T>>
+  make_host_buffer() {
+    return alpaka::allocMappedBuf<TPlatform, std::remove_extent_t<T>, Idx>(host, *platform, Vec1D{std::extent_v<T>});
+  }
+
   // potentially cached, pinned, scalar and 1-dimensional host buffers, associated to a work queue
   // the memory is pinned according to the device associated to the queue
 
@@ -104,7 +124,7 @@ namespace cms::alpakatools {
     if constexpr (allocator_policy<alpaka::Dev<TQueue>> == AllocatorPolicy::Caching) {
       return allocCachedBuf<T, Idx>(host, queue, Scalar{});
     } else {
-      return alpaka::allocMappedBuf<alpaka::Pltf<alpaka::Dev<TQueue>>, T, Idx>(host, Scalar{});
+      return alpaka::allocMappedBuf<alpaka::Platform<alpaka::Dev<TQueue>>, T, Idx>(host, *platform, Scalar{});
     }
   }
 
@@ -114,8 +134,8 @@ namespace cms::alpakatools {
     if constexpr (allocator_policy<alpaka::Dev<TQueue>> == AllocatorPolicy::Caching) {
       return allocCachedBuf<std::remove_extent_t<T>, Idx>(host, queue, Vec1D{extent});
     } else {
-      return alpaka::allocMappedBuf<alpaka::Pltf<alpaka::Dev<TQueue>>, std::remove_extent_t<T>, Idx>(host,
-                                                                                                     Vec1D{extent});
+      return alpaka::allocMappedBuf<alpaka::Platform<alpaka::Dev<TQueue>>, std::remove_extent_t<T>, Idx>(
+          host, *platform, Vec1D{extent});
     }
   }
 
@@ -125,8 +145,8 @@ namespace cms::alpakatools {
     if constexpr (allocator_policy<alpaka::Dev<TQueue>> == AllocatorPolicy::Caching) {
       return allocCachedBuf<std::remove_extent_t<T>, Idx>(host, queue, Vec1D{std::extent_v<T>});
     } else {
-      return alpaka::allocMappedBuf<alpaka::Pltf<alpaka::Dev<TQueue>>, std::remove_extent_t<T>, Idx>(
-          host, Vec1D{std::extent_v<T>});
+      return alpaka::allocMappedBuf<alpaka::Platform<alpaka::Dev<TQueue>>, std::remove_extent_t<T>, Idx>(
+          host, *platform, Vec1D{std::extent_v<T>});
     }
   }
 

--- a/src/alpaka/AlpakaCore/alpakaWorkDiv.h
+++ b/src/alpaka/AlpakaCore/alpakaWorkDiv.h
@@ -50,7 +50,7 @@ namespace cms::alpakatools {
     } else
 #endif  // ALPAKA_ACC_GPU_HIP_ENABLED
 #if ALPAKA_SYCL_ONEAPI_CPU
-        if constexpr (std::is_same_v<TAcc, alpaka::AccCpuSyclIntel<Dim1D, Idx>>) {
+        if constexpr (std::is_same_v<TAcc, alpaka::AccCpuSycl<Dim1D, Idx>>) {
       // On GPU backends, each thread is looking at a single element:
       //   - threadsPerBlockOrElementsPerThread is the number of threads per block;
       //   - elementsPerThread is always 1.
@@ -102,7 +102,7 @@ namespace cms::alpakatools {
     } else
 #endif  // ALPAKA_ACC_GPU_HIP_ENABLED
 #ifdef ALPAKA_SYCL_ONEAPI_CPU
-        if constexpr (std::is_same_v<TAcc, alpaka::AccCpuSyclIntel<Dim, Idx>>) {
+        if constexpr (std::is_same_v<TAcc, alpaka::AccCpuSycl<Dim, Idx>>) {
       // On GPU backends, each thread is looking at a single element:
       //   - threadsPerBlockOrElementsPerThread is the number of threads per block;
       //   - elementsPerThread is always 1.

--- a/src/alpaka/AlpakaCore/alpakaWorkDiv.h
+++ b/src/alpaka/AlpakaCore/alpakaWorkDiv.h
@@ -49,6 +49,24 @@ namespace cms::alpakatools {
       return WorkDiv<Dim1D>(blocksPerGrid, threadsPerBlockOrElementsPerThread, elementsPerThread);
     } else
 #endif  // ALPAKA_ACC_GPU_HIP_ENABLED
+#if ALPAKA_SYCL_ONEAPI_CPU
+        if constexpr (std::is_same_v<TAcc, alpaka::AccCpuSyclIntel<Dim1D, Idx>>) {
+      // On GPU backends, each thread is looking at a single element:
+      //   - threadsPerBlockOrElementsPerThread is the number of threads per block;
+      //   - elementsPerThread is always 1.
+      const auto elementsPerThread = Idx{1};
+      return WorkDiv<Dim1D>(blocksPerGrid, threadsPerBlockOrElementsPerThread, elementsPerThread);
+    } else
+#endif  // ALPAKA_SYCL_ONEAPI_CPU
+#if ALPAKA_SYCL_ONEAPI_GPU
+        if constexpr (std::is_same_v<TAcc, alpaka::AccGpuSyclIntel<Dim1D, Idx>>) {
+      // On GPU backends, each thread is looking at a single element:
+      //   - threadsPerBlockOrElementsPerThread is the number of threads per block;
+      //   - elementsPerThread is always 1.
+      const auto elementsPerThread = Idx{1};
+      return WorkDiv<Dim1D>(blocksPerGrid, threadsPerBlockOrElementsPerThread, elementsPerThread);
+    } else
+#endif  // ALPAKA_SYCL_ONEAPI_GPU
     {
       // On CPU backends, run serially with a single thread per block:
       //   - threadsPerBlock is always 1;
@@ -83,6 +101,24 @@ namespace cms::alpakatools {
       return WorkDiv<Dim>(blocksPerGrid, threadsPerBlockOrElementsPerThread, elementsPerThread);
     } else
 #endif  // ALPAKA_ACC_GPU_HIP_ENABLED
+#ifdef ALPAKA_SYCL_ONEAPI_CPU
+        if constexpr (std::is_same_v<TAcc, alpaka::AccCpuSyclIntel<Dim, Idx>>) {
+      // On GPU backends, each thread is looking at a single element:
+      //   - threadsPerBlockOrElementsPerThread is the number of threads per block;
+      //   - elementsPerThread is always 1.
+      const auto elementsPerThread = Vec<Dim>::ones();
+      return WorkDiv<Dim>(blocksPerGrid, threadsPerBlockOrElementsPerThread, elementsPerThread);
+    } else
+#endif  // ALPAKA_SYCL_ONEAPI_CPU
+#ifdef ALPAKA_SYCL_ONEAPI_GPU
+        if constexpr (std::is_same_v<TAcc, alpaka::AccGpuSyclIntel<Dim, Idx>>) {
+      // On GPU backends, each thread is looking at a single element:
+      //   - threadsPerBlockOrElementsPerThread is the number of threads per block;
+      //   - elementsPerThread is always 1.
+      const auto elementsPerThread = Vec<Dim>::ones();
+      return WorkDiv<Dim>(blocksPerGrid, threadsPerBlockOrElementsPerThread, elementsPerThread);
+    } else
+#endif  // ALPAKA_SYCL_ONEAPI_GPU
     {
       // On CPU backends, run serially with a single thread per block:
       //   - threadsPerBlock is always 1;

--- a/src/alpaka/AlpakaCore/backend.h
+++ b/src/alpaka/AlpakaCore/backend.h
@@ -1,10 +1,10 @@
 #ifndef AlpakaCore_backend_h
 #define AlpakaCore_backend_h
 
-enum class Backend { SERIAL, TBB, CUDA, HIP };
+enum class Backend { SERIAL, TBB, CUDA, HIP, CPUSYCL, GPUSYCL };
 
 inline std::string const& name(Backend backend) {
-  static const std::string names[] = {"serial_sync", "tbb_async", "cuda_async", "rocm_async"};
+  static const std::string names[] = {"serial_sync", "tbb_async", "cuda_async", "rocm_async", "cpu_sycl", "gpu_sycl"};
   return names[static_cast<int>(backend)];
 }
 

--- a/src/alpaka/AlpakaCore/getDeviceCachingAllocator.h
+++ b/src/alpaka/AlpakaCore/getDeviceCachingAllocator.h
@@ -17,7 +17,7 @@ namespace cms::alpakatools {
     template <typename TDevice, typename TQueue>
     auto allocate_device_allocators() {
       using Allocator = CachingAllocator<TDevice, TQueue>;
-      auto const& devices = cms::alpakatools::devices<alpaka::Pltf<TDevice>>;
+      auto const& devices = cms::alpakatools::devices<alpaka::Platform<TDevice>>;
       auto const size = devices.size();
 
       // allocate the storage for the objects
@@ -54,7 +54,7 @@ namespace cms::alpakatools {
     static auto allocators = detail::allocate_device_allocators<TDevice, TQueue>();
 
     size_t const index = getDeviceIndex(device);
-    assert(index < cms::alpakatools::devices<alpaka::Pltf<TDevice>>.size());
+    assert(index < cms::alpakatools::devices<alpaka::Platform<TDevice>>.size());
 
     // the public interface is thread safe
     return allocators[index];

--- a/src/alpaka/AlpakaCore/getDeviceIndex.h
+++ b/src/alpaka/AlpakaCore/getDeviceIndex.h
@@ -24,6 +24,12 @@ namespace cms::alpakatools {
   inline int getDeviceIndex(alpaka::DevHipRt const& device) { return alpaka::getNativeHandle(device); }
 #endif  // ALPAKA_ACC_GPU_HIP_ENABLED
 
+#ifdef ALPAKA_ACC_SYCL_ENABLED
+  // overload for DevGenericSycl
+  inline int getDeviceIndex(alpaka::DevCpuSyclIntel const& device) { return 0; }  // FIXME_
+  inline int getDeviceIndex(alpaka::DevGpuSyclIntel const& device) { return 0; }  // FIXME_
+#endif  // ALPAKA_ACC_SYCL_ENABLED
+
 }  // namespace cms::alpakatools
 
 #endif  // AlpakaCore_getDeviceIndex_h

--- a/src/alpaka/AlpakaCore/getDeviceIndex.h
+++ b/src/alpaka/AlpakaCore/getDeviceIndex.h
@@ -26,7 +26,7 @@ namespace cms::alpakatools {
 
 #ifdef ALPAKA_ACC_SYCL_ENABLED
   // overload for DevGenericSycl
-  inline int getDeviceIndex(alpaka::DevCpuSyclIntel const& device) { return 0; }  // FIXME_
+  inline int getDeviceIndex(alpaka::DevCpuSycl const& device) { return 0; }  // FIXME_
   inline int getDeviceIndex(alpaka::DevGpuSyclIntel const& device) { return 0; }  // FIXME_
 #endif  // ALPAKA_ACC_SYCL_ENABLED
 

--- a/src/alpaka/AlpakaCore/getDeviceIndex.h
+++ b/src/alpaka/AlpakaCore/getDeviceIndex.h
@@ -2,8 +2,11 @@
 #define AlpakaCore_getDeviceIndex_h
 
 #include <alpaka/alpaka.hpp>
+#include "AlpakaCore/alpakaConfig.h"
 
 namespace cms::alpakatools {
+
+  inline std::optional<ALPAKA_ACCELERATOR_NAMESPACE::Platform> platform;
 
   // generic interface, for DevOacc and DevOmp5
   template <typename Device>
@@ -26,8 +29,8 @@ namespace cms::alpakatools {
 
 #ifdef ALPAKA_ACC_SYCL_ENABLED
   // overload for DevGenericSycl
-  inline int getDeviceIndex(alpaka::DevCpuSycl const& device) { return 0; }  // FIXME_
-  inline int getDeviceIndex(alpaka::DevGpuSyclIntel const& device) { return 0; }  // FIXME_
+  inline int getDeviceIndex(alpaka::DevCpuSycl const& device) { return 0; }  //std::find(platform.syclDevices().begin(), platform.syclDevices().end(), device) - platform.syclDevices().begin(); }  // FIXME_
+  inline int getDeviceIndex(alpaka::DevGpuSyclIntel const& device) { return 0; } //std::find(platform.syclDevices().begin(), platform.syclDevices().end(), device) - platform.syclDevices().begin(); }  // FIXME_
 #endif  // ALPAKA_ACC_SYCL_ENABLED
 
 }  // namespace cms::alpakatools

--- a/src/alpaka/AlpakaCore/initialise.h
+++ b/src/alpaka/AlpakaCore/initialise.h
@@ -8,18 +8,31 @@ namespace cms::alpakatools {
   template <typename TPlatform>
   void initialise();
 
+  template <typename TPlatform>
+  void resetDevices();
+
   // explicit template instantiation declaration
 #ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_PRESENT
   extern template void initialise<alpaka_serial_sync::Platform>();
+  extern template void resetDevices<alpaka_serial_sync::Platform>();
 #endif
 #ifdef ALPAKA_ACC_CPU_B_TBB_T_SEQ_PRESENT
   extern template void initialise<alpaka_tbb_async::Platform>();
+  extern template void resetDevices<alpaka_tbb_async::Platform>();
 #endif
 #ifdef ALPAKA_ACC_GPU_CUDA_PRESENT
   extern template void initialise<alpaka_cuda_async::Platform>();
+  extern template void resetDevices<alpaka_cuda_async::Platform>();
 #endif
 #ifdef ALPAKA_ACC_GPU_HIP_PRESENT
   extern template void initialise<alpaka_rocm_async::Platform>();
+  extern template void resetDevices<alpaka_rocm_async::Platform>();
+#endif
+#ifdef ALPAKA_ACC_SYCL_PRESENT
+  extern template void initialise<alpaka_cpu_sycl::Platform>();
+  extern template void initialise<alpaka_gpu_sycl::Platform>();
+  extern template void resetDevices<alpaka_cpu_sycl::Platform>();
+  extern template void resetDevices<alpaka_gpu_sycl::Platform>();
 #endif
 
 }  // namespace cms::alpakatools

--- a/src/alpaka/AlpakaDataFormats/LayerTilesAlpaka.h
+++ b/src/alpaka/AlpakaDataFormats/LayerTilesAlpaka.h
@@ -15,20 +15,11 @@ using alpakaVect = cms::alpakatools::VecArray<int, LayerTilesConstants::maxTileD
 #if !defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 struct int4 {
   int x, y, z, w;
-}; 
+};
 #endif
 
 class LayerTilesAlpaka {
 public:
-
-  template <typename TAcc>
-  ALPAKA_FN_ACC inline constexpr void fill(TAcc& acc, const std::vector<float>& x, const std::vector<float>& y) {
-    auto cellsSize = x.size();
-    for (unsigned int i = 0; i < cellsSize; ++i) {
-      layerTiles_[getGlobalBin(x[i], y[i])].push_back(acc, i);
-    }
-  }
-
   template <typename TAcc>
   ALPAKA_FN_ACC inline constexpr void fill(TAcc& acc, float x, float y, int i) {
     layerTiles_[getGlobalBin(x, y)].push_back(acc, i);
@@ -38,7 +29,7 @@ public:
     int xBin = (x - LayerTilesConstants::minX) * LayerTilesConstants::rX;
     xBin = (xBin < LayerTilesConstants::nColumns ? xBin : LayerTilesConstants::nColumns - 1);
     bool xBinPositive = xBin > 0;
-    xBin = xBinPositive*xBin;
+    xBin = xBinPositive * xBin;
     return xBin;
   }
 
@@ -46,7 +37,7 @@ public:
     int yBin = (y - LayerTilesConstants::minY) * LayerTilesConstants::rY;
     yBin = (yBin < LayerTilesConstants::nRows ? yBin : LayerTilesConstants::nRows - 1);
     bool yBinPositive = yBin > 0;
-    yBin = yBinPositive*yBin;
+    yBin = yBinPositive * yBin;
     return yBin;
   }
   ALPAKA_FN_HOST_ACC inline constexpr int getGlobalBin(float x, float y) const {
@@ -66,15 +57,9 @@ public:
       t.reset();
   }
 
-  ALPAKA_FN_HOST_ACC inline constexpr void clear(int i) {
-    layerTiles_[i].reset();
-  }
+  ALPAKA_FN_HOST_ACC inline constexpr void clear(int i) { layerTiles_[i].reset(); }
 
-  ALPAKA_FN_HOST_ACC inline constexpr auto size() {
-    return LayerTilesConstants::nColumns * LayerTilesConstants::nRows;
-  }
-
-
+  ALPAKA_FN_HOST_ACC inline constexpr auto size() { return LayerTilesConstants::nColumns * LayerTilesConstants::nRows; }
 
   ALPAKA_FN_HOST_ACC inline constexpr alpakaVect& operator[](int globalBinId) { return layerTiles_[globalBinId]; }
 

--- a/src/alpaka/AlpakaDataFormats/alpaka/ClusterCollectionAlpaka.h
+++ b/src/alpaka/AlpakaDataFormats/alpaka/ClusterCollectionAlpaka.h
@@ -7,6 +7,25 @@
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
+  class ClusterCollectionAlpakaView { // dpcpp bug, cannot find nested classes in ALPAKA_ACCELERATOR_NAMESPACE
+  public:
+    float *x;
+    float *y;
+    float *z;
+    float *eta;
+    float *phi;
+    float *r_over_absz;
+    float *radius;
+    int *layer;
+    float *energy;
+    int *isSilicon;
+    float *rho;
+    std::pair<float, int> *delta;
+    int *nearestHigher;
+    int *isSeed;
+    int *tracksterIndex;
+  };
+
   class ClusterCollectionAlpaka {
   public:
     ClusterCollectionAlpaka() = delete;
@@ -70,25 +89,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     cms::alpakatools::device_buffer<Device, int[]> nearestHigher;
     cms::alpakatools::device_buffer<Device, int[]> isSeed;
     cms::alpakatools::device_buffer<Device, int[]> tracksterIndex;
-
-    class ClusterCollectionAlpakaView {
-    public:
-      float *x;
-      float *y;
-      float *z;
-      float *eta;
-      float *phi;
-      float *r_over_absz;
-      float *radius;
-      int *layer;
-      float *energy;
-      int *isSilicon;
-      float *rho;
-      std::pair<float, int> *delta;
-      int *nearestHigher;
-      int *isSeed;
-      int *tracksterIndex;
-    };
 
     ClusterCollectionAlpakaView *view() { return view_d.data(); }
 

--- a/src/alpaka/AlpakaDataFormats/alpaka/PointsCloudAlpaka.h
+++ b/src/alpaka/AlpakaDataFormats/alpaka/PointsCloudAlpaka.h
@@ -9,6 +9,19 @@
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
+  class PointsCloudAlpakaView { // dpcpp bug, cannot find nested classes in ALPAKA_ACCELERATOR_NAMESPACE
+  public:
+    float *x;
+    float *y;
+    int *layer;
+    float *weight;
+    float *rho;
+    float *delta;
+    int *nearestHigher;
+    int *clusterIndex;
+    int *isSeed;
+  };
+
   class PointsCloudAlpaka {
   public:
     PointsCloudAlpaka() = delete;
@@ -54,19 +67,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     cms::alpakatools::device_buffer<Device, int[]> nearestHigher;
     cms::alpakatools::device_buffer<Device, int[]> clusterIndex;
     cms::alpakatools::device_buffer<Device, int[]> isSeed;
-
-    class PointsCloudAlpakaView {
-    public:
-      float *x;
-      float *y;
-      int *layer;
-      float *weight;
-      float *rho;
-      float *delta;
-      int *nearestHigher;
-      int *clusterIndex;
-      int *isSeed;
-    };
 
     PointsCloudAlpakaView *view() { return view_d.data(); }
 

--- a/src/alpaka/Makefile
+++ b/src/alpaka/Makefile
@@ -10,6 +10,7 @@ test_cpu: $(TARGET)
 	@echo "Testing $(TARGET)"
 	$(TARGET) --maxEvents 2 --serial
 	$(TARGET) --maxEvents 2 --tbb
+	$(TARGET) --maxEvents 2 --syclcpu
 	@echo "Succeeded"
 test_nvidiagpu: $(TARGET)
 	@echo
@@ -22,6 +23,9 @@ test_amdgpu: $(TARGET)
 	$(TARGET) --maxEvents 2 --hip
 	@echo "Succeeded"
 test_intelgpu:
+	@echo "Testing $(TARGET)"
+	$(TARGET) --maxEvents 2 --syclgpu
+	@echo "Succeeded"
 test_auto:
 .PHONY: test_cpu test_nvidiagpu test_amdgpu test_intelgpu test_auto
 
@@ -37,6 +41,9 @@ MY_CXXFLAGS += -DALPAKA_ACC_GPU_CUDA_PRESENT -DALPAKA_ACC_GPU_CUDA_ONLY_MODE
 endif
 ifdef ROCM_BASE
 MY_CXXFLAGS += -DALPAKA_ACC_GPU_HIP_PRESENT -DALPAKA_ACC_GPU_HIP_ONLY_MODE
+endif
+ifdef SYCL_BASE
+MY_CXXFLAGS += -DALPAKA_ACC_SYCL_PRESENT -DALPAKA_ACC_SYCL_ONLY_MODE
 endif
 MY_LDFLAGS := -ldl -Wl,-rpath,$(LIB_DIR)/$(TARGET_NAME)
 LIB_LDFLAGS := -L$(LIB_DIR)/$(TARGET_NAME)
@@ -77,6 +84,20 @@ $(1)_CUDA_LDFLAGS := -l$(1)_cuda
 $(1)_CUOBJ := $$($(1)_CUDA_OBJ)
 $(1)_CUDADLINK := $$(if $$(strip $$($(1)_CUOBJ)),$(OBJ_DIR)/$(TARGET_NAME)/$(1)/lib$(1)_cudalink.o)
 endif
+# SYCL CPU backend
+ifdef SYCL_BASE
+$(1)_SYCL_CPU_OBJ := $$(patsubst $(SRC_DIR)%,$(OBJ_DIR)%,$$($(1)_PORTABLE_SRC:%=%.syclcpu.o))
+$(1)_SYCL_CPU_DEP := $$($(1)_SYCL_CPU_OBJ:$.o=$.d)
+$(1)_SYCL_CPU_LIB := $(LIB_DIR)/$(TARGET_NAME)/lib$(1)_syclcpu.so
+LIBS += $$($(1)_SYCL_CPU_LIB)
+$(1)_SYCL_CPU_LDFLAGS := -l$(1)_syclcpu
+# SYCL GPU backend
+$(1)_SYCL_GPU_OBJ := $$(patsubst $(SRC_DIR)%,$(OBJ_DIR)%,$$($(1)_PORTABLE_SRC:%=%.syclgpu.o))
+$(1)_SYCL_GPU_DEP := $$($(1)_SYCL_GPU_OBJ:$.o=$.d)
+$(1)_SYCL_GPU_LIB := $(LIB_DIR)/$(TARGET_NAME)/lib$(1)_syclgpu.so
+LIBS += $$($(1)_SYCL_GPU_LIB)
+$(1)_SYCL_GPU_LDFLAGS := -l$(1)_syclgpu
+endif
 # ROCm backend
 ifdef ROCM_BASE
 $(1)_ROCM_OBJ := $$(patsubst $(SRC_DIR)%,$(OBJ_DIR)%,$$($(1)_PORTABLE_SRC:%=%.rocm.o))
@@ -86,7 +107,7 @@ LIBS += $$($(1)_ROCM_LIB)
 $(1)_ROCM_LDFLAGS := -l$(1)_rocm
 endif
 endif # if PORTABLE_SRC is not empty
-ALL_DEPENDS += $$($(1)_DEP) $$($(1)_SERIAL_DEP) $$($(1)_TBB_DEP) $$($(1)_CUDA_DEP) $$($(1)_ROCM_DEP)
+ALL_DEPENDS += $$($(1)_DEP) $$($(1)_SERIAL_DEP) $$($(1)_TBB_DEP) $$($(1)_CUDA_DEP) $$($(1)_ROCM_DEP) $$($(1)_SYCL_CPU_DEP) $$($(1)_SYCL_GPU_DEP)
 endef
 $(foreach lib,$(LIBNAMES),$(eval $(call LIB_template,$(lib))))
 
@@ -124,6 +145,22 @@ PLUGINNAMES += $(1)_cuda
 $(1)_CUOBJ := $$($(1)_CUDA_OBJ)
 $(1)_CUDADLINK := $$(if $$(strip $$($(1)_CUOBJ)),$(OBJ_DIR)/$(TARGET_NAME)/plugin-$(1)/plugin$(1)_cudadlink.o,)
 endif
+# SYCL CPU backend
+ifdef SYCL_BASE
+$(1)_SYCL_CPU_OBJ := $$(patsubst $(SRC_DIR)%,$(OBJ_DIR)%,$$($(1)_PORTABLE_SRC:%=%.syclcpu.o))
+$(1)_SYCL_CPU_DEP := $$($(1)_SYCL_CPU_OBJ:$.o=$.d)
+$(1)_SYCL_CPU_LIB := $(LIB_DIR)/$(TARGET_NAME)/plugin$(1)_syclcpu.so
+PLUGINS += $$($(1)_SYCL_CPU_LIB)
+PLUGINNAMES += $(1)_syclcpu
+endif
+# SYCL GPU backend
+ifdef SYCL_BASE
+$(1)_SYCL_GPU_OBJ := $$(patsubst $(SRC_DIR)%,$(OBJ_DIR)%,$$($(1)_PORTABLE_SRC:%=%.syclgpu.o))
+$(1)_SYCL_GPU_DEP := $$($(1)_SYCL_GPU_OBJ:$.o=$.d)
+$(1)_SYCL_GPU_LIB := $(LIB_DIR)/$(TARGET_NAME)/plugin$(1)_syclgpu.so
+PLUGINS += $$($(1)_SYCL_GPU_LIB)
+PLUGINNAMES += $(1)_syclgpu
+endif
 # ROCm backend
 ifdef ROCM_BASE
 $(1)_ROCM_OBJ := $$(patsubst $(SRC_DIR)%,$(OBJ_DIR)%,$$($(1)_PORTABLE_SRC:%=%.rocm.o))
@@ -133,7 +170,7 @@ PLUGINS += $$($(1)_ROCM_LIB)
 PLUGINNAMES += $(1)_rocm
 endif
 endif # if PORTABLE_SRC is not empty
-ALL_DEPENDS += $$($(1)_DEP) $$($(1)_SERIAL_DEP) $$($(1)_TBB_DEP) $$($(1)_CUDA_DEP) $$($(1)_ROCM_DEP)
+ALL_DEPENDS += $$($(1)_DEP) $$($(1)_SERIAL_DEP) $$($(1)_TBB_DEP) $$($(1)_CUDA_DEP) $$($(1)_ROCM_DEP) $$($(1)_SYCL_CPU_DEP) $$($(1)_SYCL_GPU_DEP)
 endef
 $(foreach lib,$(PLUGINNAMES),$(eval $(call PLUGIN_template,$(lib))))
 
@@ -154,6 +191,18 @@ TESTS_CUDA_DEP := $(TESTS_CUDA_OBJ:$.o=$.d)
 TESTS_CUDA_EXE := $(patsubst $(SRC_DIR)/$(TARGET_NAME)/test/alpaka/%.cc,$(TEST_DIR)/$(TARGET_NAME)/%.cuda,$(TESTS_PORTABLE_SRC))
 TESTS_CUDADLINK := $(TESTS_CUDA_OBJ:$cu.o=$cudadlink.o)
 endif
+# SYCL CPU backend
+ifdef SYCL_BASE
+TESTS_SYCL_CPU_OBJ := $(patsubst $(SRC_DIR)%,$(OBJ_DIR)%,$(TESTS_PORTABLE_SRC:%=%.syclcpu.o))
+TESTS_SYCL_CPU_DEP := $(TESTS_SYC_CPU_OBJ:$.o=$.d)
+TESTS_SYCL_CPU_EXE := $(patsubst $(SRC_DIR)/$(TARGET_NAME)/test/alpaka/%.cc,$(TEST_DIR)/$(TARGET_NAME)/%.syclcpu,$(TESTS_PORTABLE_SRC))
+endif
+# SYCL GPU backend
+ifdef SYCL_BASE
+TESTS_SYCL_GPU_OBJ := $(patsubst $(SRC_DIR)%,$(OBJ_DIR)%,$(TESTS_PORTABLE_SRC:%=%.syclgpu.o))
+TESTS_SYCL_GPU_DEP := $(TESTS_SYC_GPU_OBJ:$.o=$.d)
+TESTS_SYCL_GPU_EXE := $(patsubst $(SRC_DIR)/$(TARGET_NAME)/test/alpaka/%.cc,$(TEST_DIR)/$(TARGET_NAME)/%.syclgpu,$(TESTS_PORTABLE_SRC))
+endif
 # ROCm backend
 ifdef ROCM_BASE
 TESTS_ROCM_OBJ := $(patsubst $(SRC_DIR)%,$(OBJ_DIR)%,$(TESTS_PORTABLE_SRC:%=%.rocm.o))
@@ -161,10 +210,10 @@ TESTS_ROCM_DEP := $(TESTS_ROCM_OBJ:$.o=$.d)
 TESTS_ROCM_EXE := $(patsubst $(SRC_DIR)/$(TARGET_NAME)/test/alpaka/%.cc,$(TEST_DIR)/$(TARGET_NAME)/%.rocm,$(TESTS_PORTABLE_SRC))
 endif
 #
-TESTS_EXE := $(TESTS_SERIAL_EXE) $(TESTS_TBB_EXE) $(TESTS_CUDA_EXE) $(TESTS_ROCM_EXE)
-ALL_DEPENDS += $(TESTS_SERIAL_DEP) $(TESTS_TBB_DEP) $(TESTS_CUDA_DEP) $(TESTS_ROCM_DEP)
+TESTS_EXE := $(TESTS_SERIAL_EXE) $(TESTS_TBB_EXE) $(TESTS_CUDA_EXE) $(TESTS_ROCM_EXE) $(TESTS_SYCL_CPU_EXE) $(TESTS_SYCL_GPU_EXE)
+ALL_DEPENDS += $(TESTS_SERIAL_DEP) $(TESTS_TBB_DEP) $(TESTS_CUDA_DEP) $(TESTS_ROCM_DEP) $(TESTS_SYCL_CPU_DEP) $(TESTS_SYCL_GPU_DEP)
 # Needed to keep the unit test object files after building $(TARGET)
-.SECONDARY: $(TESTS_SERIAL_OBJ) $(TESTS_TBB_OBJ) $(TESTS_CUDA_OBJ) $(TESTS_CUDADLINK) $(TESTS_ROCM_OBJ)
+.SECONDARY: $(TESTS_SERIAL_OBJ) $(TESTS_TBB_OBJ) $(TESTS_CUDA_OBJ) $(TESTS_CUDADLINK) $(TESTS_ROCM_OBJ) $(TESTS_SYCL_CPU_OBJ) $(TESTS_SYCL_GPU_OBJ)
 
 define RUNTEST_template
 run_$(1): $(1)
@@ -178,6 +227,8 @@ $(foreach test,$(TESTS_SERIAL_EXE),$(eval $(call RUNTEST_template,$(test),cpu)))
 $(foreach test,$(TESTS_TBB_EXE),$(eval $(call RUNTEST_template,$(test),cpu)))
 $(foreach test,$(TESTS_CUDA_EXE),$(eval $(call RUNTEST_template,$(test),nvidiagpu)))
 $(foreach test,$(TESTS_ROCM_EXE),$(eval $(call RUNTEST_template,$(test),amdgpu)))
+$(foreach test,$(TESTS_SYCL_CPU_EXE),$(eval $(call RUNTEST_template,$(test),cpu)))
+$(foreach test,$(TESTS_SYCL_GPU_EXE),$(eval $(call RUNTEST_template,$(test),intelgpu)))
 
 -include $(ALL_DEPENDS)
 
@@ -187,12 +238,12 @@ $(LIB_DIR)/$(TARGET_NAME)/plugins.txt: $(PLUGINS)
 
 $(TARGET): $(EXE_OBJ) $(LIBS) $(PLUGINS) $(LIB_DIR)/$(TARGET_NAME)/plugins.txt | $(TESTS_EXE)
 	# Link all libraries, also the "portable" ones
-	$(CXX) $(EXE_OBJ) $(LDFLAGS) $(MY_LDFLAGS) -o $@ -L$(LIB_DIR)/$(TARGET_NAME) $(foreach lib,$(LIBNAMES),$($(lib)_LDFLAGS) $($(lib)_SERIAL_LDFLAGS) $($(lib)_TBB_LDFLAGS) $($(lib)_CUDA_LDFLAGS) $($(lib)_ROCM_LDFLAGS)) $(foreach dep,$(EXTERNAL_DEPENDS),$($(dep)_LDFLAGS))
+	$(SYCL_CXX) $(EXE_OBJ) $(LDFLAGS) $(MY_LDFLAGS) -o $@ -L$(LIB_DIR)/$(TARGET_NAME) $(foreach lib,$(LIBNAMES),$($(lib)_LDFLAGS) $($(lib)_SERIAL_LDFLAGS) $($(lib)_TBB_LDFLAGS) $($(lib)_CUDA_LDFLAGS) $($(lib)_ROCM_LDFLAGS) $($(lib)_SYCL_CPU_LDFLAGS) $($(lib)_SYCL_GPU_LDFLAGS)) $(foreach dep,$(EXTERNAL_DEPENDS),$($(dep)_LDFLAGS))
 
 define BUILD_template
 $(OBJ_DIR)/$(2)/%.cc.o: $(SRC_DIR)/$(2)/%.cc
 	@[ -d $$(@D) ] || mkdir -p $$(@D)
-	$(CXX) $(CXXFLAGS) $(MY_CXXFLAGS) $$(foreach dep,$(EXTERNAL_DEPENDS),$$($$(dep)_CXXFLAGS)) -c $$< -o $$@ -MMD
+	$(SYCL_CXX) $(SYCL_CXXFLAGS) $(MY_CXXFLAGS) $$(foreach dep,$(EXTERNAL_DEPENDS),$$($$(dep)_CXXFLAGS)) -c $$< -o $$@ -MMD
 	@cp $(OBJ_DIR)/$(2)/$$*.cc.d $(OBJ_DIR)/$(2)/$$*.cc.d.tmp; \
 	  sed 's#\($(2)/$$*\)\.o[ :]*#\1.o \1.d : #g' < $(OBJ_DIR)/$(2)/$$*.cc.d.tmp > $(OBJ_DIR)/$(2)/$$*.cc.d; \
 	  sed -e 's/#.*//' -e 's/^[^:]*: *//' -e 's/ *\\$$$$//' \
@@ -201,7 +252,7 @@ $(OBJ_DIR)/$(2)/%.cc.o: $(SRC_DIR)/$(2)/%.cc
 
 $$($(1)_LIB): $$($(1)_OBJ) $$(foreach dep,$(EXTERNAL_DEPENDS),$$($$(dep)_DEPS)) $$(foreach lib,$$($(1)_DEPENDS),$$($$(lib)_LIB))
 	@[ -d $$(@D) ] || mkdir -p $$(@D)
-	$(CXX) $$($(1)_OBJ) $(LDFLAGS) -shared $(SO_LDFLAGS) $(LIB_LDFLAGS) $$(foreach lib,$$($(1)_DEPENDS),$$($$(lib)_LDFLAGS)) $$(foreach dep,$(EXTERNAL_DEPENDS),$$($$(dep)_LDFLAGS)) -o $$@
+	$(SYCL_CXX) $$($(1)_OBJ) $(LDFLAGS) -shared $(SO_LDFLAGS) $(LIB_LDFLAGS) $$(foreach lib,$$($(1)_DEPENDS),$$($$(lib)_LDFLAGS)) $$(foreach dep,$(EXTERNAL_DEPENDS),$$($$(dep)_LDFLAGS)) -o $$@
 
 $$($(1)_SERIAL_LIB): $$($(1)_SERIAL_OBJ) $$(foreach dep,$(EXTERNAL_DEPENDS),$$($$(dep)_DEPS)) $$(foreach lib,$$($(1)_DEPENDS),$$($$(lib)_LIB)) $$(foreach lib,$$($(1)_DEPENDS),$$($$(lib)_SERIAL_LIB))
 	@[ -d $$(@D) ] || mkdir -p $$(@D)
@@ -218,6 +269,15 @@ $$($(1)_CUDA_LIB): $$($(1)_CUDA_OBJ) $$($(1)_CUDADLINK) $$(foreach dep,$(EXTERNA
 $$($(1)_ROCM_LIB): $$($(1)_ROCM_OBJ) $$(foreach dep,$(EXTERNAL_DEPENDS_H),$$($$(dep)_DEPS)) $$(foreach lib,$$($(1)_DEPENDS),$$($$(lib)_LIB)) $$(foreach lib,$$($(1)_DEPENDS),$$($$(lib)_ROCM_LIB))
 	@[ -d $$(@D) ] || mkdir -p $$(@D)
 	$(CXX) $$($(1)_ROCM_OBJ) $(LDFLAGS) -shared $(SO_LDFLAGS) $(LIB_LDFLAGS) $$(foreach lib,$$($(1)_DEPENDS),$$($$(lib)_LDFLAGS)) $$(foreach lib,$$($(1)_DEPENDS),$$($$(lib)_ROCM_LDFLAGS)) $$(foreach dep,$(EXTERNAL_DEPENDS),$$($$(dep)_LDFLAGS)) -o $$@
+
+$$($(1)_SYCL_CPU_LIB): $$($(1)_SYCL_CPU_OBJ) $$(foreach dep,$(EXTERNAL_DEPENDS_H),$$($$(dep)_DEPS)) $$(foreach lib,$$($(1)_DEPENDS),$$($$(lib)_LIB)) $$(foreach lib,$$($(1)_DEPENDS),$$($$(lib)_SYCL_CPU_LIB))
+	@[ -d $$(@D) ] || mkdir -p $$(@D)
+	$(SYCL_CXX) $(SYCL_CXXFLAGS) $$($(1)_SYCL_CPU_OBJ) $(LDFLAGS) -shared $(SO_LDFLAGS) $(LIB_LDFLAGS) $$(foreach lib,$$($(1)_DEPENDS),$$($$(lib)_LDFLAGS)) $$(foreach lib,$$($(1)_DEPENDS),$$($$(lib)_SYCL_CPU_LDFLAGS)) $$(foreach dep,$(EXTERNAL_DEPENDS),$$($$(dep)_LDFLAGS)) -o $$@
+
+$$($(1)_SYCL_GPU_LIB): $$($(1)_SYCL_GPU_OBJ) $$(foreach dep,$(EXTERNAL_DEPENDS_H),$$($$(dep)_DEPS)) $$(foreach lib,$$($(1)_DEPENDS),$$($$(lib)_LIB)) $$(foreach lib,$$($(1)_DEPENDS),$$($$(lib)_SYCL_GPU_LIB))
+	@[ -d $$(@D) ] || mkdir -p $$(@D)
+	$(SYCL_CXX) $(SYCL_CXXFLAGS) $$($(1)_SYCL_GPU_OBJ) $(LDFLAGS) -shared $(SO_LDFLAGS) $(LIB_LDFLAGS) $$(foreach lib,$$($(1)_DEPENDS),$$($$(lib)_LDFLAGS)) $$(foreach lib,$$($(1)_DEPENDS),$$($$(lib)_SYCL_GPU_LDFLAGS)) $$(foreach dep,$(EXTERNAL_DEPENDS),$$($$(dep)_LDFLAGS)) -o $$@
+
 
 # Anything depending on Alpaka
 # Portable code, for serial backend
@@ -250,6 +310,21 @@ $$($(1)_CUDADLINK): $$($(1)_CUOBJ)
 	$(CUDA_NVCC) $(CUDA_DLINKFLAGS) $(CUDA_LDFLAGS) $$($(1)_CUOBJ) -o $$@
 endif
 
+# Portable code, for SYCL CPU backend
+ifdef SYCL_BASE
+$(OBJ_DIR)/$(2)/alpaka/%.cc.syclcpu.o: $(SRC_DIR)/$(2)/alpaka/%.cc
+	@[ -d $$(@D) ] || mkdir -p $$(@D)
+	$(SYCL_CXX) $(SYCL_CXXFLAGS) $(MY_CXXFLAGS) -DALPAKA_ACC_SYCL_ENABLED -DALPAKA_SYCL_BACKEND_ONEAPI -DALPAKA_SYCL_ONEAPI_CPU -UALPAKA_HOST_ONLY $$(foreach dep,$(EXTERNAL_DEPENDS),$$($$(dep)_CXXFLAGS)) $$(foreach dep,$(EXTERNAL_DEPENDS),$$($$(dep)_SYCL_CXXFLAGS)) -c $$< -o $$@ -MMD
+endif
+
+# Portable code, for SYCL GPU backend
+ifdef SYCL_BASE
+$(OBJ_DIR)/$(2)/alpaka/%.cc.syclgpu.o: $(SRC_DIR)/$(2)/alpaka/%.cc
+	@[ -d $$(@D) ] || mkdir -p $$(@D)
+	$(SYCL_CXX) $(SYCL_CXXFLAGS) $(MY_CXXFLAGS) -DALPAKA_ACC_SYCL_ENABLED -DALPAKA_SYCL_BACKEND_ONEAPI -DALPAKA_SYCL_ONEAPI_GPU -UALPAKA_HOST_ONLY $$(foreach dep,$(EXTERNAL_DEPENDS),$$($$(dep)_CXXFLAGS)) $$(foreach dep,$(EXTERNAL_DEPENDS),$$($$(dep)_SYCL_CXXFLAGS)) -c $$< -o $$@ -MMD
+endif
+
+
 # Portable code, for ROCm backend
 ifdef ROCM_BASE
 $(OBJ_DIR)/$(2)/alpaka/%.cc.rocm.o: $(SRC_DIR)/$(2)/alpaka/%.cc
@@ -264,7 +339,7 @@ $(foreach lib,$(PLUGINNAMES),$(eval $(call BUILD_template,$(lib),$(TARGET_NAME)/
 
 $(OBJ_DIR)/$(TARGET_NAME)/bin/%.cc.o: $(SRC_DIR)/$(TARGET_NAME)/bin/%.cc
 	@[ -d $(@D) ] || mkdir -p $(@D)
-	$(CXX) $(CXXFLAGS) $(MY_CXXFLAGS) $(foreach dep,$(EXTERNAL_DEPENDS),$($(dep)_CXXFLAGS)) -c $< -o $@ -MMD
+	$(SYCL_CXX) $(SYCL_CXXFLAGS) $(MY_CXXFLAGS) $(foreach dep,$(EXTERNAL_DEPENDS),$($(dep)_CXXFLAGS)) -c $< -o $@ -MMD
 	@cp $(@D)/$*.cc.d $(@D)/$*.cc.d.tmp; \
 	  sed 's#\($(TARGET_NAME)/$*\)\.o[ :]*#\1.o \1.d : #g' < $(@D)/$*.cc.d.tmp > $(@D)/$*.cc.d; \
 	  sed -e 's/#.*//' -e 's/^[^:]*: *//' -e 's/ *\\$$//' \
@@ -323,4 +398,26 @@ $(OBJ_DIR)/$(TARGET_NAME)/test/alpaka/%.cc.rocm.o: $(SRC_DIR)/$(TARGET_NAME)/tes
 $(TEST_DIR)/$(TARGET_NAME)/%.rocm: $(OBJ_DIR)/$(TARGET_NAME)/test/alpaka/%.cc.rocm.o | $(LIBS)
 	@[ -d $(@D) ] || mkdir -p $(@D)
 	$(CXX) $^ $(LDFLAGS) $(MY_LDFLAGS) -o $@ -L$(LIB_DIR)/$(TARGET_NAME) $(foreach lib,$(LIBNAMES),$($(lib)_LDFLAGS) $($(lib)_ROCM_LDFLAGS)) $(foreach dep,$(EXTERNAL_DEPENDS),$($(dep)_LDFLAGS))
+endif
+
+# SYCL CPU backend
+ifdef SYCL_BASE
+$(OBJ_DIR)/$(TARGET_NAME)/test/alpaka/%.cc.syclcpu.o: $(SRC_DIR)/$(TARGET_NAME)/test/alpaka/%.cc
+	@[ -d $(@D) ] || mkdir -p $(@D)
+	$(SYCL_CXX) $(SYCL_CXXFLAGS) $(SYCL_TEST_CXXFLAGS) $(MY_CXXFLAGS) -DALPAKA_ACC_SYCL_ENABLED -DALPAKA_SYCL_BACKEND_ONEAPI -DALPAKA_SYCL_ONEAPI_CPU -UALPAKA_HOST_ONLY $(foreach dep,$(EXTERNAL_DEPENDS),$($(dep)_CXXFLAGS)) -c $< -o $@ -MMD
+
+$(TEST_DIR)/$(TARGET_NAME)/%.syclcpu: $(OBJ_DIR)/$(TARGET_NAME)/test/alpaka/%.cc.syclcpu.o | $(LIBS)
+	@[ -d $(@D) ] || mkdir -p $(@D)
+	$(SYCL_CXX) $(SYCL_CXXFLAGS) $^ $(LDFLAGS) $(MY_LDFLAGS) -o $@ -L$(LIB_DIR)/$(TARGET_NAME) $(foreach lib,$(LIBNAMES),$($(lib)_LDFLAGS) $($(lib)_SYCL_CPU_LDFLAGS)) $(foreach dep,$(EXTERNAL_DEPENDS),$($(dep)_LDFLAGS))
+endif
+
+# SYCL GPU backend
+ifdef SYCL_BASE
+$(OBJ_DIR)/$(TARGET_NAME)/test/alpaka/%.cc.syclgpu.o: $(SRC_DIR)/$(TARGET_NAME)/test/alpaka/%.cc
+	@[ -d $(@D) ] || mkdir -p $(@D)
+	$(SYCL_CXX) $(SYCL_CXXFLAGS) $(SYCL_TEST_CXXFLAGS) $(MY_CXXFLAGS) -DALPAKA_ACC_SYCL_ENABLED -DALPAKA_SYCL_BACKEND_ONEAPI -DALPAKA_SYCL_ONEAPI_GPU -UALPAKA_HOST_ONLY $(foreach dep,$(EXTERNAL_DEPENDS),$($(dep)_CXXFLAGS)) -c $< -o $@ -MMD
+
+$(TEST_DIR)/$(TARGET_NAME)/%.syclgpu: $(OBJ_DIR)/$(TARGET_NAME)/test/alpaka/%.cc.syclgpu.o | $(LIBS)
+	@[ -d $(@D) ] || mkdir -p $(@D)
+	$(SYCL_CXX) $(SYCL_CXXFLAGS) $^ $(LDFLAGS) $(MY_LDFLAGS) -o $@ -L$(LIB_DIR)/$(TARGET_NAME) $(foreach lib,$(LIBNAMES),$($(lib)_LDFLAGS) $($(lib)_SYCL_GPU_LDFLAGS)) $(foreach dep,$(EXTERNAL_DEPENDS),$($(dep)_LDFLAGS))
 endif

--- a/src/alpaka/plugin-CLUEClusterizer/alpaka/CLUEAlgoKernels.h
+++ b/src/alpaka/plugin-CLUEClusterizer/alpaka/CLUEAlgoKernels.h
@@ -6,7 +6,7 @@
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
-  using pointsView = PointsCloudAlpaka::PointsCloudAlpakaView;
+  using pointsView = PointsCloudAlpakaView;
 
   struct KernelResetHist {
     template <typename TAcc>

--- a/src/alpaka/plugin-CLUETracksterizer/alpaka/CLUE3DAlgoKernels.h
+++ b/src/alpaka/plugin-CLUETracksterizer/alpaka/CLUE3DAlgoKernels.h
@@ -12,7 +12,13 @@
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
-  using pointsView = ClusterCollectionAlpaka::ClusterCollectionAlpakaView;
+#ifdef ALPAKA_ACC_SYCL_ENABLED
+  using sycl::abs;
+#else
+  using std::abs;
+#endif
+
+  using pointsView = ClusterCollectionAlpakaView;
 
   struct KernelResetHist {
     template <typename TAcc>
@@ -42,7 +48,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       // push index of points into tiles
       cms::alpakatools::for_each_element_in_grid(acc, numberOfPoints, [&](uint32_t clusterIdx) {
         d_hist[d_points->layer[clusterIdx]].fill(
-            acc, std::abs(d_points->eta[clusterIdx]), d_points->phi[clusterIdx], clusterIdx);
+            acc, abs(d_points->eta[clusterIdx]), d_points->phi[clusterIdx], clusterIdx);
       });
     }
   };
@@ -189,7 +195,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                 //              auto const &clustersOnOtherLayer = points[currentLayer];
                 auto dist = maxDelta;
                 auto dist_transverse = maxDelta;
-                int dist_layers = std::abs(currentLayer - layerId);
+                int dist_layers = abs(currentLayer - layerId);
                 dist_transverse = distanceSqr(d_points->r_over_absz[clusterIdx] * d_points->z[clusterIdx],
                                               d_points->r_over_absz[otherClusterIdx] * d_points->z[clusterIdx],
                                               d_points->phi[clusterIdx],

--- a/src/alpaka/test/alpaka/hello.cc
+++ b/src/alpaka/test/alpaka/hello.cc
@@ -14,6 +14,12 @@ int main() {
 #if defined ALPAKA_ACC_GPU_HIP_ENABLED
             << "HIP/ROCm "
 #endif
+#if defined ALPAKA_SYCL_ONEAPI_CPU
+            << "SYCL CPU "
+#endif
+#if defined ALPAKA_SYCL_ONEAPI_GPU
+            << "SYCL GPU "
+#endif
             << "backend" << std::endl;
   return 0;
 }

--- a/src/alpaka/test/alpaka/world.cc
+++ b/src/alpaka/test/alpaka/world.cc
@@ -18,7 +18,8 @@ int main() {
   std::cout << "World" << std::endl;
 
   using namespace ALPAKA_ACCELERATOR_NAMESPACE;
-  const Device device(alpaka::getDevByIdx<Platform>(0u));
+  std::optional<Platform> platform = Platform{};
+  const Device device(alpaka::getDevByIdx(*platform, 0u));
   Queue queue(device);
 
   // Prepare 1D workDiv

--- a/src/sycl/bin/main.cc
+++ b/src/sycl/bin/main.cc
@@ -64,7 +64,6 @@ int main(int argc, char** argv) try {
     } else if (*i == "--device") {
       ++i;
       std::string device = *i;
-      device += ",host";
       setenv("SYCL_DEVICE_FILTER", device.c_str(), true);
     } else if (*i == "--dim") {
       ++i;


### PR DESCRIPTION
This PR implements the necessary changes in the framework to allow Alpaka to work with the SYCL backend for both CPUs and GPUs. This backend is still in its experimental phase, see  the status of the relevant PR in the Alpaka repository [#1845](https://github.com/alpaka-group/alpaka/pull/1845).
The code for the algorithms has been left untouched, all the necessary changes were made to Alpaka and the way it interfaces with the framework